### PR TITLE
Issue #33: Don't claim that Moo and namespace::clean are bundled

### DIFF
--- a/Kernel/System/Environment.pm
+++ b/Kernel/System/Environment.pm
@@ -274,7 +274,6 @@ sub PerlInfoGet {
             MIME::Tools
             Module::Find
             Module::Refresh
-            Moo
             Mozilla::CA
             Net::IMAP::Simple
             Net::HTTP
@@ -287,7 +286,6 @@ sub PerlInfoGet {
             Types::TypeTiny
             YAML
             URI
-            namespace::clean
             )
             )
         {


### PR DESCRIPTION
This was a mistake in commit b539a662533 of the ((OTRS)) Community Edition