### PR TITLE
Issue #82: Fix CREATE USER statement.

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -536,11 +536,11 @@ sub Run {
                 # a case switch must be used here.
                 my $CreateUserSQL = "CREATE USER `$DB{OTOBODBUser}`\@`$Host` IDENTIFIED WITH mysql_native_password";
                 {
-                    if ( $DBH->{server_info} =~ m/mariadb/i ) {
-                        $CreateUserSQL .= " BY '$DB{OTOBODBPassword}'",
+                    if ( $DBH->{mysql_serverinfo} =~ m/mariadb/i ) {
+                        $CreateUserSQL .= " AS PASSWORD('$DB{OTOBODBPassword}')",
                     }
                     else {
-                        $CreateUserSQL .= " AS PASSWORD('$DB{OTOBODBPassword}')",
+                        $CreateUserSQL .= " BY '$DB{OTOBODBPassword}'",
                     }
                 }
 


### PR DESCRIPTION
Mixed up the two alternatives.
Coincidentally work for MariaDB, as the mysql_serverinfo check was messed up too.