### PR TITLE
Issue #161: returning 127.0.0.1 for the local addr is fine

### DIFF
--- a/scripts/test/GenericInterface/Operation/Session/SessionGet.t
+++ b/scripts/test/GenericInterface/Operation/Session/SessionGet.t
@@ -391,7 +391,7 @@ my @Tests = (
                     },
                     {
                         Key   => 'UserRemoteAddr',
-                        Value => 'none',
+                        Value => '127.0.0.1',
                     },
                     {
                         Key   => 'UserRemoteUserAgent',
@@ -443,7 +443,7 @@ my @Tests = (
                     },
                     {
                         Key   => 'UserRemoteAddr',
-                        Value => 'none',
+                        Value => '127.0.0.1',
                     },
                     {
                         Key   => 'UserRemoteUserAgent',


### PR DESCRIPTION
Unittest are running on the same machine. Therefore 127.0.0.1 is fine.