### PR TITLE
Issue #206: Make sure that the UserTimeZone is UTC

### DIFF
--- a/scripts/test/SysConfig/SettingEffectiveValueCheck.t
+++ b/scripts/test/SysConfig/SettingEffectiveValueCheck.t
@@ -26,12 +26,24 @@ use vars (qw($Self));
 
 use Kernel::Config;
 
-# Get needed objects
+# declare specific settings for the test
+
+# RestoreDatabase
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {
         RestoreDatabase => 1,
     },
 );
+
+# Set the timezone of root@localhost to UTC.
+# This is needed for 'DateTime - pass' and for 'Date - pass'
+$Kernel::OM->Get('Kernel::System::User')->SetPreferences(
+    Key    => 'UserTimeZone',
+    Value  => 'UTC',
+    UserID => 1,
+);
+
+# Get needed objects
 my $HelperObject      = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 my $SysConfigObject   = $Kernel::OM->Get('Kernel::System::SysConfig');
 my $ConfigObject      = $Kernel::OM->Get('Kernel::Config');


### PR DESCRIPTION
This fixes the test for the case when the UserTimeZone initially is not 'UTC'.