### PR TITLE
Issue #242: Set locale ot C.UTF-8

### DIFF
--- a/otobo.elasticsearch.dockerfile
+++ b/otobo.elasticsearch.dockerfile
@@ -1,9 +1,13 @@
 # This is the build file for the OTOBO Elasticsearch docker image.
 # See also README_DOCKER.md.
 
-# Use 7.8.0, cause latest flag is not availible
+# Use 7.8.0, because latest flag is not available
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.8.0
 
 # Install important plugins
 RUN bin/elasticsearch-plugin install --batch ingest-attachment
 RUN bin/elasticsearch-plugin install --batch analysis-icu
+
+# We want an UTF-8 console
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8

--- a/otobo.nginx.dockerfile
+++ b/otobo.nginx.dockerfile
@@ -8,6 +8,10 @@ FROM nginx:mainline
 EXPOSE 80/tcp
 EXPOSE 443/tcp
 
+# We want an UTF-8 console
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 # This setting works in the devel environment.
 # In the general case OTOBO_NGINX_WEB_HOST can be set when starting the container:
 #   docker run -e OTOBO_NGINX_WEB_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+') -p 443:443 otobo_nginx

--- a/otobo.web.dockerfile
+++ b/otobo.web.dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update \
     && apt-get -y --no-install-recommends install tree vim nano default-mysql-client cron \
     && rm -rf /var/lib/apt/lists/*
 
+# We want an UTF-8 console
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 # A minimal copy so that the Docker cache is not busted
 COPY cpanfile ./cpanfile
 


### PR DESCRIPTION
ENV LC_ALL C.UTF-8
ENV LANG C.UTF-8
'locales' do not have to be installed.
The warnings from otobo.Console.pl disappeared.
vim seems to use utf-8 per default