### PR TITLE
Issue #191: Fixed the single 'No plan found' warning

### DIFF
--- a/Kernel/System/UnitTest/Driver.pm
+++ b/Kernel/System/UnitTest/Driver.pm
@@ -563,6 +563,23 @@ sub DoneTesting {
     return $Self->Plan( Tests => $TestCountTotal );
 }
 
+=head2 Note()
+
+Print out notes to STDOUT. The parameter B<Note> will be split into lines and each line
+is prepended by '# '. A trailing newline will be added when there isn't on yet.
+
+=cut
+
+sub Note {
+    my ($Self, %Param) = @_;
+
+    my $Note = $Param{Note} // '';
+    chomp $Note;
+    print { $Self->{OriginalSTDOUT} } map { "# $_\n" } split /\n/, $Note;
+
+    return;
+}
+
 =begin Internal:
 
 =cut

--- a/scripts/test/Console/Command/Dev/Tools/Config2Docbook.t
+++ b/scripts/test/Console/Command/Dev/Tools/Config2Docbook.t
@@ -60,6 +60,6 @@ $Self->True(
     "Config entry found in docbook content",
 );
 
-print $Result;
+$Self->Note( Note => $Result );
 
 1;


### PR DESCRIPTION
Add the method Note() to Kernel::System::UnitTest::Driver