### PR TITLE
Issue #388: explicit check for 'Z' in _StringToHash()

### DIFF
--- a/Kernel/System/DateTime.pm
+++ b/Kernel/System/DateTime.pm
@@ -1965,8 +1965,15 @@ sub _StringToHash {
         };
 
         # Check if the rest 'OffsetOrTZ' is an offset or timezone.
-        #   If isn't an offset consider it a timezone
-        if ( $OffsetOrTZ ne 'Z' && $OffsetOrTZ !~ m/[+-]\d{2}:?(?:\d{2})?/i ) {
+        # Explicit support for Zulu time.
+        # Then ff isn't an offset consider it a timezone.
+        if ( $OffsetOrTZ eq 'Z' ) {
+            return {
+                %{$DateTimeHash},
+                TimeZone => 'UTC',
+            };
+        }
+        elsif ( $OffsetOrTZ !~ m/[+-]\d{2}:?(?:\d{2})?/i ) {
 
             # Make sure the time zone is valid. Otherwise, assume UTC.
             if ( !$Self->IsTimeZoneValid( TimeZone => $OffsetOrTZ ) ) {


### PR DESCRIPTION
Z is not recognised as a timezone, special case it in order to make it obvious.