### PR TITLE
Issue RotherOSS/otobo-docker#6: run on high port number

### DIFF
--- a/otobo.nginx.dockerfile
+++ b/otobo.nginx.dockerfile
@@ -15,9 +15,10 @@ RUN apt-get update\
  "vim"\
  && rm -rf /var/lib/apt/lists/*
 
-# mostly for documentation
-EXPOSE 80/tcp
-EXPOSE 443/tcp
+# No need to run on the low ports 80 and 443,
+# even though this would be possible as the master process runs as root.
+EXPOSE 8080/tcp
+EXPOSE 8443/tcp
 
 # We want an UTF-8 console
 ENV LC_ALL C.UTF-8

--- a/scripts/nginx/templates/otobo_nginx.conf.template
+++ b/scripts/nginx/templates/otobo_nginx.conf.template
@@ -1,20 +1,21 @@
 # Config for nginx serving as a reverse proxy for the OTOBO web application.
-# The static files are served directly by nginx.
-# TODO: set caching headers for the static files.
 
 # This config is based on default.conf in the nginx installation
+
+# The master process runs as root.
+# When no user is configured then the workers will run as nobody.
+#user
 
 proxy_send_timeout 120;
 proxy_read_timeout 300;
 proxy_buffering    off;
 tcp_nodelay        on;
 
-
 # Do not serve HTTP, redirect to HTTPS instead.
 # See https://linuxize.com/post/redirect-http-to-https-in-nginx/.
 server {
-    listen 80;
-    listen [::]:80;
+    listen 8080;
+    listen [::]:8080;
 
     # catch all domains
     server_name _;
@@ -25,8 +26,8 @@ server {
 
 # serve HTTPS
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 8443 ssl;
+    listen [::]:8443 ssl;
 
     # see https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-18-04
     include snippets/ssl-params.conf;


### PR DESCRIPTION
Avoid the ports that can only be run as root.