### PR TITLE
Issue #351: remove all Apache version checks

### DIFF
--- a/scripts/apache2-httpd-fcgi.include.conf
+++ b/scripts/apache2-httpd-fcgi.include.conf
@@ -41,19 +41,9 @@ ProxyPassReverse "/otobo/" "fcgi://localhost:4000/otobo/"
 <Directory "/opt/otobo/var/httpd/htdocs/">
     AllowOverride None
 
-    <IfModule mod_version.c>
-        <IfVersion < 2.4>
-            Order allow,deny
-            Allow from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all granted
-        </IfVersion>
-    </IfModule>
-    <IfModule !mod_version.c>
-        Order allow,deny
-        Allow from all
-    </IfModule>
+    # Require supported starting with Apache 2.4
+    # No authentication and all requests are allowed.
+    Require all granted
 
     <IfModule mod_filter.c>
         <IfModule mod_deflate.c>

--- a/scripts/apache2-httpd-plack-proxy.include.conf
+++ b/scripts/apache2-httpd-plack-proxy.include.conf
@@ -29,19 +29,9 @@ ProxyPassReverse "/otobo/" "http://localhost:5000/otobo/"
 <Directory "/opt/otobo/var/httpd/htdocs/">
     AllowOverride None
 
-    <IfModule mod_version.c>
-        <IfVersion < 2.4>
-            Order allow,deny
-            Allow from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all granted
-        </IfVersion>
-    </IfModule>
-    <IfModule !mod_version.c>
-        Order allow,deny
-        Allow from all
-    </IfModule>
+    # Require supported starting with Apache 2.4
+    # No authentication and all requests are allowed.
+    Require all granted
 
     <IfModule mod_filter.c>
         <IfModule mod_deflate.c>

--- a/scripts/apache2-httpd-vhost-443.include.conf
+++ b/scripts/apache2-httpd-vhost-443.include.conf
@@ -58,19 +58,10 @@
             PerlOptions +ParseHeaders
             PerlOptions +SetupEnv
 
-            <IfModule mod_version.c>
-                <IfVersion < 2.4>
-                    Order allow,deny
-                    Allow from all
-                </IfVersion>
-                <IfVersion >= 2.4>
-                    Require all granted
-                </IfVersion>
-            </IfModule>
-            <IfModule !mod_version.c>
-                Order allow,deny
-                Allow from all
-            </IfModule>
+            # Require supported starting with Apache 2.4
+            # No authentication and all requests are allowed.
+            Require all granted
+
         </Location>
 
         # mod_perl2 options for GenericInterface
@@ -84,19 +75,9 @@
         AllowOverride None
         Options +ExecCGI -Includes
 
-        <IfModule mod_version.c>
-            <IfVersion < 2.4>
-                Order allow,deny
-                Allow from all
-            </IfVersion>
-            <IfVersion >= 2.4>
-                Require all granted
-            </IfVersion>
-        </IfModule>
-        <IfModule !mod_version.c>
-            Order allow,deny
-            Allow from all
-        </IfModule>
+        # Require supported starting with Apache 2.4
+        # No authentication and all requests are allowed.
+        Require all granted
 
         <IfModule mod_filter.c>
             <IfModule mod_deflate.c>
@@ -109,19 +90,9 @@
     <Directory "/opt/otobo/var/httpd/htdocs/">
         AllowOverride None
 
-        <IfModule mod_version.c>
-            <IfVersion < 2.4>
-                Order allow,deny
-                Allow from all
-            </IfVersion>
-            <IfVersion >= 2.4>
-                Require all granted
-            </IfVersion>
-        </IfModule>
-        <IfModule !mod_version.c>
-            Order allow,deny
-            Allow from all
-        </IfModule>
+        # Require supported starting with Apache 2.4
+        # No authentication and all requests are allowed.
+        Require all granted
 
         <IfModule mod_filter.c>
             <IfModule mod_deflate.c>

--- a/scripts/apache2-httpd.include.conf
+++ b/scripts/apache2-httpd.include.conf
@@ -26,19 +26,10 @@ Alias /otobo-web/ "/opt/otobo/var/httpd/htdocs/"
         PerlOptions +ParseHeaders
         PerlOptions +SetupEnv
 
-        <IfModule mod_version.c>
-            <IfVersion < 2.4>
-                Order allow,deny
-                Allow from all
-            </IfVersion>
-            <IfVersion >= 2.4>
-                Require all granted
-            </IfVersion>
-        </IfModule>
-        <IfModule !mod_version.c>
-            Order allow,deny
-            Allow from all
-        </IfModule>
+        # Require supported starting with Apache 2.4
+        # No authentication and all requests are allowed.
+        Require all granted
+
     </Location>
 
     # mod_perl2 options for GenericInterface
@@ -52,19 +43,9 @@ Alias /otobo-web/ "/opt/otobo/var/httpd/htdocs/"
     AllowOverride None
     Options +ExecCGI -Includes
 
-    <IfModule mod_version.c>
-        <IfVersion < 2.4>
-            Order allow,deny
-            Allow from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all granted
-        </IfVersion>
-    </IfModule>
-    <IfModule !mod_version.c>
-        Order allow,deny
-        Allow from all
-    </IfModule>
+    # Require supported starting with Apache 2.4
+    # No authentication and all requests are allowed.
+    Require all granted
 
     <IfModule mod_filter.c>
         <IfModule mod_deflate.c>
@@ -77,19 +58,9 @@ Alias /otobo-web/ "/opt/otobo/var/httpd/htdocs/"
 <Directory "/opt/otobo/var/httpd/htdocs/">
     AllowOverride None
 
-    <IfModule mod_version.c>
-        <IfVersion < 2.4>
-            Order allow,deny
-            Allow from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all granted
-        </IfVersion>
-    </IfModule>
-    <IfModule !mod_version.c>
-        Order allow,deny
-        Allow from all
-    </IfModule>
+    # Require supported starting with Apache 2.4
+    # No authentication and all requests are allowed.
+    Require all granted
 
     <IfModule mod_filter.c>
         <IfModule mod_deflate.c>
@@ -109,19 +80,11 @@ Alias /otobo-web/ "/opt/otobo/var/httpd/htdocs/"
 # Allow access to public interface for unauthenticated requests on systems with set-up authentication.
 # Will work only for RegistrationUpdate, since page resources are still not be loaded.
 # <Location /otobo/public.pl>
-#     <IfModule mod_version.c>
-#         <IfVersion < 2.4>
-#             Order allow,deny
-#             Allow from all
-#         </IfVersion>
-#         <IfVersion >= 2.4>
-#             Require all granted
-#         </IfVersion>
-#     </IfModule>
-#     <IfModule !mod_version.c>
-#         Order allow,deny
-#         Allow from all
-#     </IfModule>
+#
+#    # Require supported starting with Apache 2.4
+#    # No authentication and all requests are allowed.
+#    Require all granted
+#
 # </Location>
 
 <IfModule mod_headers.c>


### PR DESCRIPTION
Apache prior to 2.4 won't work because 'Require' was added in 2.4.