### PR TITLE
Fix email validation when email is kinda ok

### DIFF
--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -122,8 +122,9 @@ sub CheckEmail {
     # remove comment from address when checking.
     $Param{Address} =~ s{ \s* \( [^()]* \) \s* $ }{}smxg;
 
+    $Param{Address} = Email::Valid->address( $Param{Address} );
     # email address syntax check
-    if ( !Email::Valid->address( $Param{Address} ) ) {
+    if ( !$Param{Address} ) {
         $Error = "Invalid syntax";
         $Self->{ErrorType} = 'InvalidSyntax';
     }


### PR DESCRIPTION
Hi everyone!
The method `Email::Valid->address( $Param{Address} )` returns `undef` if the parameter is not a valid email, otherwise it returns the email "validated" so without spaces, for example.

If you set "test@gmail .com" as a recipient, the method above returns a string: the email "validated", so "test@gmail.com".
Doing so, the `if` check in the Perl code considers it valid and goes on.
The send fails because of the space in the recipient email.

With the proposed change, it will no longer fail when sending "kind of correct" email addresses as the one above.