### PR TITLE
add ConfigSettings similar to AgentTicketClose #594

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -14450,12 +14450,33 @@ Thanks for your help!
             <Item ValueType="String" ValueRegex="">Ticket was closed</Item>
         </Value>
     </Setting>
-
     <Setting Name="Znuny4OTOBO::QuickClose::State" Required="0" Valid="1">
         <Description Translatable="1">Defines the close state for quick close.</Description>
         <Navigation>Core::Znuny4OTOBO::QuickClose</Navigation>
         <Value>
             <Item ValueType="Entity" ValueEntityType="State" ValueRegex="">closed successful</Item>
+        </Value>
+    </Setting>
+    <Setting Name="Ticket::Frontend::AgentTicketZnuny4OTOBOQuickClose###RequiredLock" Required="0" Valid="1">
+        <Description Translatable="1">Defines if a ticket lock is required for quick close of the agent interface (if the ticket isn't locked yet, the ticket gets locked and the current agent will be set automatically as its owner).</Description>
+        <Navigation>Frontend::Agent::View::AgentTicketZnuny4OTOBOQuickClose</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">1</Item>
+        </Value>
+    </Setting>
+    <Setting Name="Ticket::Frontend::AgentTicketZnuny4OTOBOQuickClose###Permission" Required="1" Valid="1">
+        <Description Translatable="1">Required permissions to use quick close ticket in the agent interface.</Description>
+        <Navigation>Frontend::Agent::View::AgentTicketZnuny4OTOBOQuickClose</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">close</Item>
+        </Value>
+    </Setting>
+<!-- TODO: necessary? OwnerMandatory has no impact -->
+    <Setting Name="Ticket::Frontend::AgentTicketZnuny4OTOBOQuickClose###OwnerMandatory" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+        <Description Translatable="1">Sets if ticket owner must be selected by the agent.</Description>
+        <Navigation>Frontend::Agent::View::AgentTicketZnuny4OTOBOQuickClose</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
     <Setting Name="Ticket::Frontend::MenuModule###451-QuickClose" Required="0" Valid="1">


### PR DESCRIPTION
Avoids menu entry `Quick Close` in AgentTicketZoom if ticket has been locked by an other agent.

Direct `Quick Close` via URL parameter `Action=AgentTicketZnuny4OTOBOQuickClose` is still possible.