### PR TITLE
Fix HTTP::REST Transport error if request body is empty

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -760,8 +760,16 @@ sub RequesterPerformRequest {
     }
     push @RequestParam, $Controller;
 
-    if ( IsStringWithData( $Param{Data} ) ) {
-        $Body = $Param{Data};
+    # Only POST, PUT or PATCH have a body. If it is empty
+    # (i. e. $Param{Data} = {}), undef is passed to REST::Client.
+    if ( $RestCommand eq 'POST'
+         || $RestCommand eq 'PUT'
+         || $RestCommand eq 'PATCH'
+         ) {
+        if ( IsStringWithData( $Param{Data} ) ) {
+            $Body = $Param{Data};
+        }
+
         push @RequestParam, $Body;
     }
 


### PR DESCRIPTION
In OTRS 6 if you'd perform an request using the HTTP::REST backend that had a empty request body (i. e. `{ Data => {}, }`), it would fail with this error message:

```
Not a SCALAR reference at /opt/otrs/bin/cgi-bin/../../Kernel/cpan-lib/LWP/Protocol/http.pm line 256.
```

This is caused by `REST::Client` missing its body argument. The solution is to pass `undef` as body argument if our body turns out to be empty.

This issue is still present in OTOBO and can be fixed by the very same patch which has been taken from <https://github.com/OTRS/otrs/pull/2028> where you may find additional context.