### PR TITLE
Issue #632: remove remnants of the usage of Expand

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -393,7 +393,7 @@ sub Run {
         qw(
         NewStateID NewPriorityID TimeUnits IsVisibleForCustomer Title Body Subject NewQueueID
         Year Month Day Hour Minute NewOwnerID NewResponsibleID TypeID ServiceID SLAID
-        Expand ReplyToArticle StandardTemplateID CreateArticle FormDraftID Title
+        ReplyToArticle StandardTemplateID CreateArticle FormDraftID Title
         )
         )
     {
@@ -759,12 +759,6 @@ sub Run {
             )
         {
             $Error{'TimeUnitsInvalid'} = ' ServerError';
-        }
-
-        # check expand
-        if ( $GetParam{Expand} ) {
-            %Error = ();
-            $Error{Expand} = 1;
         }
 
         # skip validation of hidden fields

--- a/Kernel/Modules/CustomerTicketMessage.pm
+++ b/Kernel/Modules/CustomerTicketMessage.pm
@@ -79,7 +79,7 @@ sub Run {
     # get params
     my %GetParam;
     my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
-    for my $Key (qw( Subject Body PriorityID TypeID ServiceID SLAID Expand Dest FromChatID)) {
+    for my $Key (qw( Subject Body PriorityID TypeID ServiceID SLAID Dest FromChatID)) {
         $GetParam{$Key} = $ParamObject->GetParam( Param => $Key );
     }
 
@@ -624,8 +624,8 @@ sub Run {
 
             my $ValidationResult;
 
-            # do not validate on attachment upload or GetParam Expand
-            if ( !$GetParam{Expand} && $Visibility{ $DynamicFieldConfig->{Name} } ) {
+            # do not validate on insisible fields
+            if ( $Visibility{ $DynamicFieldConfig->{Name} } ) {
 
                 $ValidationResult = $BackendObject->EditFieldValueValidate(
                     DynamicFieldConfig   => $DynamicFieldConfig,
@@ -695,7 +695,7 @@ sub Run {
         }
 
         # check queue
-        if ( !$NewQueueID && !$GetParam{Expand} ) {
+        if ( !$NewQueueID ) {
             $Error{QueueInvalid} = 'ServerError';
         }
 
@@ -737,10 +737,6 @@ sub Run {
         if ( !$GetParam{Body} ) {
             $Error{BodyInvalid} = 'ServerError';
         }
-        if ( $GetParam{Expand} ) {
-            %Error = ();
-            $Error{Expand} = 1;
-        }
 
         # check mandatory service
         if (
@@ -765,12 +761,7 @@ sub Run {
         }
 
         # check type
-        if (
-            $ConfigObject->Get('Ticket::Type')
-            && !$GetParam{TypeID}
-            && !$GetParam{Expand}
-            )
-        {
+        if ( $ConfigObject->Get('Ticket::Type') && !$GetParam{TypeID}) {
             $Error{TypeIDInvalid} = 'ServerError';
         }
 

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogHeader.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/ActivityDialogHeader.tt
@@ -68,7 +68,6 @@
             <input type="hidden" name="LinkTicketID" value="[% Data.LinkTicketID | html %]"/>
             <input type="hidden" name="ProcessEntityID" value="[% Data.ProcessEntityID | html %]"/>
             <input type="hidden" name="ActivityDialogEntityID" value="[% Data.ActivityDialogEntityID | html %]"/>
-            <input type="hidden" name="Expand" id="Expand" value=""/>
             <input type="hidden" name="IsMainWindow" id="IsMainWindow" value="[% Data.IsMainWindow | html %]"/>
             <input type="hidden" name="IsProcessEnroll" id="IsProcessEnroll" value="[% Data.IsProcessEnroll | html %]"/>
             <input type="hidden" name="FormID" value="[% Data.FormID | html %]"/>

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogHeader.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerActivityDialogHeader.tt
@@ -22,7 +22,6 @@
             <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
             <input type="hidden" name="ProcessEntityID" value="[% Data.ProcessEntityID | html %]"/>
             <input type="hidden" name="ActivityDialogEntityID" value="[% Data.ActivityDialogEntityID | html %]"/>
-            <input type="hidden" name="Expand" id="Expand" value=""/>
             <input type="hidden" name="AJAXDialog" id="AJAXDialog" value="[% Data.AJAXDialog | html %]"/>
             <input type="hidden" name="IsMainWindow" id="IsMainWindow" value="[% IF !Data.TicketID %]1[% END %]"/>
             <input type="hidden" name="FormID" value="[% Data.FormID | html %]"/>


### PR DESCRIPTION
Remove the unused hidden field 'Expand'.
Remove the useless checks for Expand.
Don't emit errors when an useless param Expand is passed.