### PR TITLE
Issue #682: jquery selectors don' work well with generated nodes

### DIFF
--- a/scripts/test/Selenium/Agent/AgentSplitSelectionACL.t
+++ b/scripts/test/Selenium/Agent/AgentSplitSelectionACL.t
@@ -149,16 +149,16 @@ EOF
         $Selenium->WaitFor(
             JavaScript => 'return $("#SplitSubmit").length'
         );
-        $Self->True(
-            $Selenium->execute_script(
-                "return \$(\"#SplitSelection option[value='PhoneTicket']\").length === 1"
-            ),
-            "Split option for 'Phone Ticket' is enabled.",
+        $Self->False(
+            $Selenium->find_element_by_xpath( q{//option[@value='SnailMailTicket']} ),
+            "Split option for 'SnailMail Ticket' not available.",
         );
         $Self->True(
-            $Selenium->execute_script(
-                "return \$(\"#SplitSelection option[value='EmailTicket']\").length === 0"
-            ),
+            $Selenium->find_element_by_xpath( q{//option[@value='PhoneTicket']} ),
+            "Split option for 'Phone Ticket' is enabled.",
+        );
+        $Self->False(
+            $Selenium->find_element_by_xpath( q{//option[@value='EmailTicket']} ),
             "Split option for 'Email Ticket' is disabled.",
         );
         $Selenium->find_element( '.Close', 'css' )->click();


### PR DESCRIPTION
xpath queries seem to use the current state of the DOM.
Instead of checking the length, simple check whether noded are
found with xpath. Added a test for an option the surely does not exist.