### PR TITLE
fix for GenericInterface: If one ticket has less articles than a give…

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketGet.pm
@@ -348,6 +348,7 @@ sub Run {
     # start ticket loop
     TICKET:
     for my $TicketID (@TicketIDs) {
+        my $TicketArticleLimit = $ArticleLimit;
 
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
@@ -436,15 +437,15 @@ sub Run {
 
         # Modify ArticleLimit if it is greater then number of articles (see bug#14585).
         if ( $ArticleLimit > scalar @Articles ) {
-            $ArticleLimit = scalar @Articles;
+            $TicketArticleLimit = scalar @Articles;
         }
 
         # Set number of articles by ArticleLimit and ArticleOrder parameters.
-        if ( IsArrayRefWithData( \@Articles ) && $ArticleLimit ) {
+        if ( IsArrayRefWithData( \@Articles ) && $TicketArticleLimit ) {
             if ( $ArticleOrder eq 'DESC' ) {
                 @Articles = reverse @Articles;
             }
-            @Articles = @Articles[ 0 .. ( $ArticleLimit - 1 ) ];
+            @Articles = @Articles[ 0 .. ( $TicketArticleLimit - 1 ) ];
         }
 
         # start article loop


### PR DESCRIPTION
…n article limit, the article limit is set to the number of articles in that article.

And that new article limit is taken for all subsequent tickets as well. See https://github.com/znuny/Znuny/issues/16