### PR TITLE
Implement StartTLS support for LDAP auth modules

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -473,6 +473,8 @@ sub LoadDefaults {
 #        async   => 0,
 #        version => 3,
 #    };
+    # Net::LDAP::start_tls verify type (if needed - for more info see Net::LDAP::start_tls)
+#    $Self->{'AuthModule::LDAP::StartTLS'} = 'required';
 
     # Die if backend can't work, e. g. can't connect to server.
 #    $Self->{'AuthModule::LDAP::Die'} = 1;
@@ -566,6 +568,9 @@ sub LoadDefaults {
 #        async   => 0,
 #        version => 3,
 #    };
+    # Net::LDAP::start_tls verify type (if needed - for more info see Net::LDAP::start_tls)
+#    $Self->{'AuthSyncModule::LDAP::StartTLS'} = 'required';
+
 
     # Die if backend can't work, e. g. can't connect to server.
 #    $Self->{'AuthSyncModule::LDAP::Die'} = 1;
@@ -1393,6 +1398,8 @@ via the Preferences button after logging in.
 #        async   => 0,
 #        version => 3,
 #    };
+    # Net::LDAP::start_tls verify type (if needed - for more info see Net::LDAP::start_tls)
+#    $Self->{'Customer::AuthModule::LDAP::StartTLS'} = 'required';
 
     # Die if backend can't work, e. g. can't connect to server.
 #    $Self->{'Customer::AuthModule::LDAP::Die'} = 1;

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -3859,6 +3859,13 @@ via the Preferences button after logging in.
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="Customer::AuthModule::LDAP::StartTLS" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">If "LDAP" was selected for Customer::AuthModule and you wish to use TLS security to communicate with the LDAP server, the "verify" parameter can be specified here. See Net::LDAP::start_tls for more information about the parameter.</Description>
+        <Navigation>Core::Auth::Customer</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">required</Item>
+        </Value>
+    </Setting>
     <Setting Name="Customer::AuthModule::LDAP::Die" Required="0" Valid="1" ConfigLevel="200">
         <Description Translatable="1">If "LDAP" was selected for Customer::AuthModule, you can specify if the applications will stop if e. g. a connection to a server can't be established due to network problems.</Description>
         <Navigation>Core::Auth::Customer</Navigation>

--- a/Kernel/System/Auth/LDAP.pm
+++ b/Kernel/System/Auth/LDAP.pm
@@ -98,6 +98,8 @@ sub new {
         $Self->{Params} = {};
     }
 
+    $Self->{StartTLS} = $ConfigObject->Get( 'AuthModule::LDAP::StartTLS' . $Param{Count} ) || '';
+
     return $Self;
 }
 
@@ -184,6 +186,22 @@ sub Auth {
                 Message  => "Can't connect to $Self->{Host}: $@",
             );
             return;
+        }
+    }
+    if ( $Self->{StartTLS} ) {
+        my $Started = $LDAP->start_tls( verify => $Self->{StartTLS} );
+        if ( !$Started ) {
+            if ( $Self->{Die} ) {
+                die "start_tls on $Self->{Host} failed: $@";
+            }
+            else {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "start_tls: '$Self->{StartTLS}' on $Self->{Host} failed: $@",
+                );
+                $LDAP->disconnect();
+                return;
+            }
         }
     }
     my $Result = '';

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -92,6 +92,8 @@ sub new {
         $Self->{Params} = {};
     }
 
+    $Self->{StartTLS} = $ConfigObject->Get( 'AuthModule::LDAP::StartTLS' . $Param{Count} ) || '';
+
     return $Self;
 }
 
@@ -133,6 +135,22 @@ sub Sync {
             Message  => "Can't connect to $Self->{Host}: $@",
         );
         return;
+    }
+    if ( $Self->{StartTLS} ) {
+        my $Started = $LDAP->start_tls( verify => $Self->{StartTLS} );
+        if ( !$Started ) {
+            if ( $Self->{Die} ) {
+                die "start_tls on $Self->{Host} failed: $@";
+            }
+            else {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "start_tls: '$Self->{StartTLS}' on $Self->{Host} failed: $@",
+                );
+                $LDAP->disconnect();
+                return;
+            }
+        }
     }
     my $Result;
     if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {

--- a/Kernel/System/CustomerAuth/LDAP.pm
+++ b/Kernel/System/CustomerAuth/LDAP.pm
@@ -104,6 +104,8 @@ sub new {
         $Self->{Params} = {};
     }
 
+    $Self->{StartTLS} = $ConfigObject->Get( 'Customer::AuthModule::LDAP::StartTLS' . $Param{Count} ) || '';
+
     return $Self;
 }
 
@@ -184,6 +186,22 @@ sub Auth {
             Message  => "Can't connect to $Self->{Host}: $@",
         );
         return;
+    }
+    if ( $Self->{StartTLS} ) {
+        my $Started = $LDAP->start_tls( verify => $Self->{StartTLS} );
+        if ( !$Started ) {
+            if ( $Self->{Die} ) {
+                die "start_tls on $Self->{Host} failed: $@";
+            }
+            else {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "start_tls: '$Self->{StartTLS}' on $Self->{Host} failed: $@",
+                );
+                $LDAP->disconnect();
+                return;
+            }
+        }
     }
     my $Result = '';
     if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {


### PR DESCRIPTION
Adds ability for LDAP connections to use start_tls, which isn't covered by the Net::LDAP::new function. Only sets/uses the verify parameter, rather than adding all the other parameters, but I'd imagine that's all 99% of people need...

Previous attempts: otrs/otrs#1888 otrs/otrs#1950 Third time lucky?