### PR TITLE
Error description in support package generation

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
@@ -102,7 +102,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
                     TextClass = 'Error';
 
                     Core.UI.Dialog.ShowContentDialog(
-                        '<div class="Spacing Center NoSupportBunle"><span class="W50pc ' + TextClass + '" title="' + ResponseMessage + '">' + ResponseMessage + '</span></div>', Core.Language.Translate("Generate Result"),
+                        '<div class="Spacing Center NoSupportBunle"><span class="W50pc ' + TextClass + '" title="' + ResponseMessage + '"><p>' + ResponseMessage + '</p><br /><p>' + Response.Message +'</p></span></div>', Core.Language.Translate("Generate Result"),
                         '10px',
                         'Center',
                         true,


### PR DESCRIPTION
Hi :)

i've added some description in the error popup in the Support Data Collector section when it fails to produce a Support Package.
Actually, the popup shows the message "_It was not possible to generate the Support Bundle._", with this push it will show the same string and the message returned from the GenerateSupportBundle subaction.

I think it might be useful for the system admin to understand the problem with the installation.

Regards