### PR TITLE
Issue #682: Don't use jquery for page generated by JS

### DIFF
--- a/scripts/test/Selenium/Agent/AgentTicketProcessAttachment.t
+++ b/scripts/test/Selenium/Agent/AgentTicketProcessAttachment.t
@@ -21,7 +21,7 @@ use utf8;
 # Set up the test driver $Self when we are running as a standalone script.
 use Kernel::System::UnitTest::RegisterDriver;
 
-use vars (qw($Self));
+our $Self;
 
 use Kernel::System::VariableCheck qw(IsHashRefWithData);
 
@@ -64,7 +64,6 @@ $Selenium->RunTest(
             $ACLObject->ACLUpdate(
                 ID   => $Item,
                 Name => $ACLList->{$Item},
-                ,
                 ValidID => 2,
                 UserID  => 1,
             );
@@ -161,7 +160,7 @@ $Selenium->RunTest(
         );
 
         # Wait until page has loaded, if necessary.
-        $Selenium->WaitFor( JavaScript => 'return typeof($) === "function" && $("#Subject").length;' );
+        $Selenium->WaitFor( ElementExists =>  [ '#Subject', 'css' ] );
 
         # Hide DnDUpload and show input field.
         $Selenium->execute_script(


### PR DESCRIPTION
The old issue that the DOM used by jquery is the original DOM, not the updated DOM.
Using a css selector without jquery seems to do the job.
Also looks like the test needs a fresh database to complete.