### PR TITLE
Added the possibility to use Core.AJAX.FormUpdate for multiple backend-actions on one page

### DIFF
--- a/var/httpd/htdocs/js/Core.AJAX.js
+++ b/var/httpd/htdocs/js/Core.AJAX.js
@@ -569,6 +569,9 @@ Core.AJAX = (function (TargetNS) {
             Data = GetAdditionalDefaultData(),
             QueryString;
 
+        $EventElement.find('input[name="AJAXAction"]').each(function () {
+            Data.Action = $(this).val();
+        });
         Data.Subaction = Subaction;
         Data.ElementChanged = ChangedElement;
         QueryString = TargetNS.SerializeForm($EventElement, Data) + SerializeData(Data);


### PR DESCRIPTION
Currently we are working on a Widget for the AgentTicketZoom-Page which uses CustomFields and a custom Custom Endpoint. Unfortunate the current Frontend uses by definition the Action used in the BrowserUrl. My Change trying to resolve this issue, by searching for an Input-Field named "Action" in the Scope of the EventElement and using it's value.