### PR TITLE
Issue #867: default value for 'Description' in a SysConfig entry

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -9542,7 +9542,7 @@ via the Preferences button after logging in.
                             <Array>
                             </Array>
                         </Item>
-                        <Item Key="Description" Translatable="1"></Item>
+                        <Item Key="Description" Translatable="1">Open the OTOBO home page in a new window</Item>
                         <Item Key="Name" Translatable="1">Jump to OTOBO!</Item>
                         <Item Key="Link">Action=ExternalURLJump;URL=http://otobo.de/</Item>
                         <Item Key="LinkOption">target="_blank"</Item>
@@ -9596,7 +9596,7 @@ via the Preferences button after logging in.
                             <Array>
                             </Array>
                         </Item>
-                        <Item Key="Description" Translatable="1">Jump to OTOBO!</Item>
+                        <Item Key="Description" Translatable="1">Open the OTOBO home page in a new window</Item>
                         <Item Key="Name" Translatable="1">Jump to OTOBO!</Item>
                         <Item Key="Link">Action=ExternalURLJump;URL=http://otobo.de/</Item>
                         <Item Key="LinkOption">target="_blank"</Item>


### PR DESCRIPTION
Specifically for Frontend::Navigation###ExternalURLJump###1.
'Description' is a required parameter for the ExternalJump frontend module.
When it is missing, then this option can't be easily activated in the SysConfig.