### PR TITLE
Issue #902: readd explicit DESTROY for Kernel::System::UnitTest::Helper

### DIFF
--- a/Kernel/System/UnitTest/RegisterDriver.pm
+++ b/Kernel/System/UnitTest/RegisterDriver.pm
@@ -62,4 +62,13 @@ sub import {    ## no critic qw(OTOBO::RequireCamelCase)
     return;
 }
 
+END {
+
+    # trigger Kernel::System::UnitTest::Helper::DESTROY()
+    # perform cleanup actions, including some tests, in Kernel::System::UnitTest::Helper::DESTROY
+    $Kernel::OM->ObjectsDiscard(
+        Objects => ['Kernel::System::UnitTest::Helper'],
+    );
+}
+
 1;

--- a/scripts/test/Console/Command/Admin/Package/ReinstallAll.t
+++ b/scripts/test/Console/Command/Admin/Package/ReinstallAll.t
@@ -25,15 +25,9 @@ use utf8;
 use Test2::V0;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 plan(1);
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # Temporarily disabled to work around a mod_perl bug that occurs on Ubuntu 15.04 and gentoo atm (2016-01-29).
 #

--- a/scripts/test/Console/Command/Dev/Tools/Migrate/OTRSToOTOBO.t
+++ b/scripts/test/Console/Command/Dev/Tools/Migrate/OTRSToOTOBO.t
@@ -27,15 +27,9 @@ use Test2::V0;
 use Path::Class qw(dir file);
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 plan( tests => 4 );
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Dev::Tools::Migrate::OTRSToOTOBO');
 my $Home          = $Kernel::OM->Get('Kernel::Config')->Get('Home');
@@ -43,15 +37,16 @@ my $Home          = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 subtest
     'error with missing parameter --target',
     sub {
-        my ($ExitCode, $Stderr);
+        my ( $ExitCode, $Stderr );
         {
             local *STDERR;
-            open STDERR, '>:encoding(UTF-8)', \$Stderr;
+            open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--source" => "$Home/Kernel/Config/Files/NotExisting/Source",
                 '--cleanxmlconfig',
             );
         }
+
         #note( $Stderr );
 
         # exit code 1 indicates failure
@@ -62,16 +57,17 @@ subtest
 subtest
     'error with extra parameter --source',
     sub {
-        my ($ExitCode, $Stderr);
+        my ( $ExitCode, $Stderr );
         {
             local *STDERR;
-            open STDERR, '>:encoding(UTF-8)', \$Stderr;
+            open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--target" => "$Home/Kernel/Config/Files/NotExisting/Target",
                 "--source" => "$Home/Kernel/Config/Files/NotExisting/Source",
                 '--cleanxmlconfig',
             );
         }
+
         #note( $Stderr );
 
         # exit code 1 indicates failure
@@ -82,16 +78,17 @@ subtest
 subtest
     'error with non-existing source dir',
     sub {
-        my ($ExitCode, $Stderr);
+        my ( $ExitCode, $Stderr );
         {
             local *STDERR;
-            open STDERR, '>:encoding(UTF-8)', \$Stderr;
+            open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--target" => "$Home/Kernel/Config/Files/NotExisting/Target",
                 '--cleanxmlconfig',
                 "$Home/Kernel/Config/Files/NotExisting/Source",
             );
         }
+
         #note( $Stderr );
 
         # exit code 1 indicates failure
@@ -103,28 +100,28 @@ subtest
     'actual migration',
     sub {
         # copy a sample file to a testdir
-        my $TestDir = dir($Home)->subdir('tmp/Test/Migrate/OTRSToOTOBO');
-        my $SourceDir = $TestDir->subdir( 'Source' );
+        my $TestDir   = dir($Home)->subdir('tmp/Test/Migrate/OTRSToOTOBO');
+        my $SourceDir = $TestDir->subdir('Source');
         $SourceDir->mkpath();
-        my $TargetDir = $TestDir->subdir( 'Target' );
+        my $TargetDir = $TestDir->subdir('Target');
         $TargetDir->mkpath();
 
         # copy the sample file to the test dir, the workfile will be modified later
-        my $SampleFile  = dir($Home)->file('scripts/test/sample/SysConfig/MigrateOTRSToOTOBO.xml');
-        my $SourceFile  = $SampleFile->copy_to( $SourceDir->file('MigrateOTRSToOTOBO.xml') );
-        my $TargetFile  = $TargetDir->file('MigrateOTRSToOTOBO.xml');
+        my $SampleFile = dir($Home)->file('scripts/test/sample/SysConfig/MigrateOTRSToOTOBO.xml');
+        my $SourceFile = $SampleFile->copy_to( $SourceDir->file('MigrateOTRSToOTOBO.xml') );
+        my $TargetFile = $TargetDir->file('MigrateOTRSToOTOBO.xml');
 
-        my ($ExitCode, $Stderr);
+        my ( $ExitCode, $Stderr );
         {
             local *STDERR;
-            open STDERR, '>:encoding(UTF-8)', \$Stderr;
+            open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 '--cleanxmlconfig',
                 '--target' => $TargetDir->stringify(),
                 $SourceDir->stringify(),
             );
         }
-        note( "stderr: $Stderr" );
+        note("stderr: $Stderr");
 
         # exit code 0 indicates success
         is( $ExitCode, 0, 'success' );

--- a/scripts/test/DB/QuoteIdentifiers.t
+++ b/scripts/test/DB/QuoteIdentifiers.t
@@ -24,7 +24,7 @@ use utf8;
 use Test2::V0;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 my @Tests = (
     {
@@ -60,12 +60,6 @@ my @Tests = (
 );
 
 plan( scalar @Tests );
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # get DB object
 my $DBObject = $Kernel::OM->Get('Kernel::System::DB');

--- a/scripts/test/ObjectManager/Can.t
+++ b/scripts/test/ObjectManager/Can.t
@@ -16,9 +16,10 @@
 
 use strict;
 use warnings;
+use v5.24;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 use vars (qw($Self));
 

--- a/scripts/test/ObjectManager/ObjectInstanceRegister.t
+++ b/scripts/test/ObjectManager/ObjectInstanceRegister.t
@@ -16,9 +16,10 @@
 
 use strict;
 use warnings;
+use v5.24;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 use vars (qw($Self));
 

--- a/scripts/test/ObjectManager/ObjectLifecycle.t
+++ b/scripts/test/ObjectManager/ObjectLifecycle.t
@@ -16,9 +16,10 @@
 
 use strict;
 use warnings;
+use v5.24;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 use vars (qw($Self));
 

--- a/scripts/test/ObjectManager/ObjectOnDemand.t
+++ b/scripts/test/ObjectManager/ObjectOnDemand.t
@@ -16,9 +16,14 @@
 
 use strict;
 use warnings;
+use v5.24;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+
+# CPAN modules
+
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 use vars (qw($Self));
 

--- a/scripts/test/ObjectManager/ObjectParamAdd.t
+++ b/scripts/test/ObjectManager/ObjectParamAdd.t
@@ -16,9 +16,10 @@
 
 use strict;
 use warnings;
+use v5.24;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 use vars (qw($Self));
 

--- a/scripts/test/PSGI/IndexHtml.t
+++ b/scripts/test/PSGI/IndexHtml.t
@@ -26,7 +26,7 @@ use Test2::Tools::HTTP;
 use HTTP::Request::Common;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 # This test checks whether the URLs / and /index.html work
 
@@ -35,12 +35,6 @@ use Kernel::System::ObjectManager;
 skip_all 'not running under Docker' unless $ENV{OTOBO_RUNS_UNDER_DOCKER};
 
 plan(3);
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # get needed singletons
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');

--- a/scripts/test/PSGI/RobotsTxt.t
+++ b/scripts/test/PSGI/RobotsTxt.t
@@ -26,7 +26,7 @@ use Test2::Tools::HTTP;
 use HTTP::Request::Common;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 # This test checks whether the URLs / and /index.html work
 
@@ -35,12 +35,6 @@ use Kernel::System::ObjectManager;
 skip_all 'not running under Docker' unless $ENV{OTOBO_RUNS_UNDER_DOCKER};
 
 plan(1);
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # get needed singletons
 my $ConfigObject = $Kernel::OM->Get('Kernel::Config');

--- a/scripts/test/Selenium/Agent/AgentTicketActionCommon/AgentTicketOwner.t
+++ b/scripts/test/Selenium/Agent/AgentTicketActionCommon/AgentTicketOwner.t
@@ -25,15 +25,8 @@ use utf8;
 use Test2::V0;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 use Kernel::System::UnitTest::Selenium;
-
-# because OTOBO modules expect $Kernel::OM
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # get selenium object
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );

--- a/scripts/test/Selenium/Customer/FooterLinks.t
+++ b/scripts/test/Selenium/Customer/FooterLinks.t
@@ -25,15 +25,8 @@ use utf8;
 use Test2::V0;
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 use Kernel::System::UnitTest::Selenium;
-
-# because OTOBO modules expect $Kernel::OM
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
 
 # get selenium object
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );

--- a/scripts/test/SysConfig/ConfigurationTranslatedGet.t
+++ b/scripts/test/SysConfig/ConfigurationTranslatedGet.t
@@ -18,12 +18,11 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
+use Kernel::Config;
 
 use vars (qw($Self));
-
-use Kernel::Config;
 
 $Kernel::OM->ObjectParamAdd(
     'Kernel::System::UnitTest::Helper' => {

--- a/scripts/test/UnitTest/Blacklist.t
+++ b/scripts/test/UnitTest/Blacklist.t
@@ -25,19 +25,12 @@ use utf8;
 use Test2::V0 qw(plan is note like);
 
 # OTOBO modules
-use Kernel::System::ObjectManager;
-
-$Kernel::OM = Kernel::System::ObjectManager->new(
-    'Kernel::System::Log' => {
-        LogPrefix => 'OTOBO-otobo.UnitTest',
-    },
-);
+use Kernel::System::UnitTest::RegisterDriver;    # set up $Self and $Kernel::OM
 
 plan(2);
 
-my $Helper   = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
-my $RandomID = $Helper->GetRandomID();
-
+my $Helper        = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+my $RandomID      = $Helper->GetRandomID();
 my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Dev::UnitTest::Run');
 
 my @Tests = (
@@ -79,9 +72,9 @@ for my $Test (@Tests) {
     my ( $ResultStdout, $ResultStderr, $ExitCode );
     {
         local *STDOUT;
-        open STDOUT, '>:encoding(UTF-8)', \$ResultStdout;
+        open STDOUT, '>:encoding(UTF-8)', \$ResultStdout;    ## no critic qw(OTOBO::ProhibitOpen)
         local *STDERR;
-        open STDERR, '>:encoding(UTF-8)', \$ResultStderr;
+        open STDERR, '>:encoding(UTF-8)', \$ResultStderr;    ## no critic qw(OTOBO::ProhibitOpen)
 
         $ExitCode = $CommandObject->Execute( '--test', $Test->{Test}, '--quiet' );
     }


### PR DESCRIPTION
Also, consistently use Kernel::System::UnitTest::RegisterDriver.
Altogether this is less confusing.
Simply ignore $Self when that variable is not needed.