### PR TITLE
Configurable index settings for Elasticsearch

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -9300,6 +9300,21 @@ via the Preferences button after logging in.
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="Elasticsearch::IndexSettings" Required="1" Valid="1">
+        <Description Translatable="1">Index Settings definition of Elasticsearch.</Description>
+        <Navigation>Core::Elasticsearch::Settings</Navigation>
+        <Value>
+            <Item ValueType="Textarea">
+            {
+                "index": {
+                    "number_of_shards"   : [% Data.NShards | uri %],
+                    "number_of_replicas" : [% Data.NReplicas | uri %]
+                },
+                "index.mapping.total_fields.limit" : 2000
+            }
+            </Item>
+        </Value>
+    </Setting>
     <Setting Name="Frontend::Module###AgentElasticsearchQuickResult" Required="0" Valid="1">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Navigation>Frontend::Agent::ModuleRegistration</Navigation>


### PR DESCRIPTION
Hello!

In CJK area, we sometimes want to change index settings of Elasticsearch(especially analyzer, tokenizer and filter ex: ES's plugin kuromoji(Japan), smartcn(China),  openkoreantext-analyzer(Korea)) because of default analyzer is not work well.
But it is hard-corded and can't change so I make a patch which moved to SysConfig.

There are current settings related index : Elasticsearch::ArticleIndexCreationSettings,  which is a parameter for (only) replication
so I apply template expansion and there are no effects for current users.

Added SysConfig Elasticsearch::IndexSettings is text type JSON-style parameter and can edit if we want.
            {
                "index": {
                    "number_of_shards"   : [% Data.NShards | uri %],
                    "number_of_replicas" : [% Data.NReplicas | uri %]
                },
                "index.mapping.total_fields.limit" : 2000
            }


Regards,
===
Add SysConfig Elasticsearch::IndexSettings.
When createing Elasticsearch index, Use the config JSON.

For backward compatibility of Elasticsearch::ArticleIndexCreationSettings,
Elasticsearch::IndexSettings is treated as template (you can use [% .. %])