### PR TITLE
Migration redirect stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,14 @@ var/log/ssl_request_log
 .sublimelinterrc
 .externalToolBuilders
 .gnupg
+.lesshst
 .settings
 .includepath
 .DS_Store
 .profile
 .vstags
 .vscode
+.viminfo*
 .vimrc
 
 # files that might be generated during development

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ var/log/ssl_request_log
 .profile
 .vstags
 .vscode
-.viminfo*
-.vimrc
+.vim*
 
 # files that might be generated during development
 build.log

--- a/Kernel/System/MigrateFromOTRS/OTOBOPerlModulesCheck.pm
+++ b/Kernel/System/MigrateFromOTRS/OTOBOPerlModulesCheck.pm
@@ -100,7 +100,10 @@ sub Run {
         return \%Result;
     }
 
-    my $ExitCode = system("$ScriptPath -list");
+    # do never write anything on STDOUT here. It would break the following
+    # AJAX scripts not expecting addtional information. We need the ExitCode
+    # only. So redirect STDOUT to STDERR.
+    my $ExitCode = system("$ScriptPath -list >&2");
 
     if ( $ExitCode != 0 ) {
         my %Result;


### PR DESCRIPTION
Redirect stdout to stderr for called scripts to prevent their output messing with the regular dataflow. This is relevant for setups using apache but not using mod_perl - for whatever reason.