### PR TITLE
Show create dates of tickets/articles in the customer portal

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -2096,8 +2096,9 @@ sub _Mask {
 
         # do some html quoting
         $Article{Age} = $LayoutObject->CustomerAge(
-            Age   => $Delta->{AbsoluteSeconds},
-            Space => ' ',
+            Age               => $Delta->{AbsoluteSeconds},
+            Space             => ' ',
+            DisplayCreateDate => 1,
         );
 
         $Article{Subject} = $TicketObject->TicketSubjectClean(

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -2190,6 +2190,16 @@ sub CustomerAgeInHours {
 sub CustomerAge {
     my ( $Self, %Param ) = @_;
 
+    if ( $Param{DisplayCreateDate} && $Param{Age} >= (60 * 60 * 24) ) {
+        # Display full date if it's older than 24 hours.
+        my $DateTimeObject = $Kernel::OM->Create('Kernel::System::DateTime');
+        $DateTimeObject->Subtract( Seconds => $Param{Age} );
+
+        my $DateTimeString = $DateTimeObject->ToString();
+        my $DateStrg = $Self->{LanguageObject}->FormatTimeString( $DateTimeString, 'DateFormat', 'NoSeconds' );
+        return $DateStrg;
+    }
+
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     my $Age       = defined( $Param{Age} ) ? $Param{Age} : return;

--- a/Kernel/Output/HTML/TicketOverview/CustomerList.pm
+++ b/Kernel/Output/HTML/TicketOverview/CustomerList.pm
@@ -149,8 +149,9 @@ sub Run {
 
         # Age design.
         $Ticket{CustomerAge} = $LayoutObject->CustomerAge(
-            Age   => $Ticket{Age},
-            Space => ' '
+            Age               => $Ticket{Age},
+            Space             => ' ',
+            DisplayCreateDate => 1,
         ) || 0;
 
         # return ticket information if there is no article

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.TicketList.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.TicketList.css
@@ -132,7 +132,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 .oooTicketList h3,
-.oooTicketList p {
+.oooTicketList p:not(.oooTicketItemAge) {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
As wished from Stefan, this change shows the creation date of tickets and articles in the customer portal if they are older than 24 hours.
Currently, dates are shown as "x days, x hours ago" which can be very confusing.

It might be worth considering adding a setting for this, as not every user might have set up correct time zones for their customers.