### PR TITLE
Issue #1118: add check for Apache2::Module functions

### DIFF
--- a/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/LoadedModules.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/LoadedModules.pm
@@ -47,8 +47,10 @@ sub Run {
 
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    # Check for mod_perl by trying to load Apache2::Module, that module is needed later on anyways
+    # Checking for $ENV{MOD_PERL} is not reliable, see https://github.com/plack/Plack/issues/562.
+    # Check for mod_perl by trying to load Apache2::Module and see whether Apache2::Module::top_module() is available.
     return $Self->GetResults() unless $MainObject->Require( 'Apache2::Module', Silent => 1 );
+    return $Self->GetResults() unless defined &Apache2::Module::top_module;
 
     # report name and versions of Apache modules
     for ( my $Module = Apache2::Module::top_module(); $Module; $Module = $Module->next() ) {

--- a/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/MPMModel.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/MPMModel.pm
@@ -47,8 +47,10 @@ sub Run {
 
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    # Check for mod_perl by trying to load Apache2::Module, that module is needed later on anyways
+    # Checking for $ENV{MOD_PERL} is not reliable, see https://github.com/plack/Plack/issues/562.
+    # Check for mod_perl by trying to load Apache2::Module and see whether Apache2::Module::top_module() is available.
     return $Self->GetResults() unless $MainObject->Require( 'Apache2::Module', Silent => 1 );
+    return $Self->GetResults() unless defined &Apache2::Module::top_module;
 
     my $MPMModel;
     my %KnownModels = (

--- a/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/Performance.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/Webserver/Apache/Performance.pm
@@ -48,8 +48,10 @@ sub Run {
 
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    # Check for mod_perl by trying to load Apache2::Module, that module is needed later on anyways
+    # Checking for $ENV{MOD_PERL} is not reliable, see https://github.com/plack/Plack/issues/562.
+    # Check for mod_perl by trying to load Apache2::Module and see whether Apache2::Module::loaded() is available.
     return $Self->GetResults() unless $MainObject->Require( 'Apache2::Module', Silent => 1 );
+    return $Self->GetResults() unless defined &Apache2::Module::loaded;
 
     # Check for CGI accelerator
     # We are a bit sloppy here. If Apache2::Module has been loaded we assume the effectively we have mod_perl.


### PR DESCRIPTION
These subs are not defined when mod_perl is not loaded.