### PR TITLE
Issue #961: Tests don't like settings not activated yet

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1912,12 +1912,13 @@ via the Preferences button after logging in.
     # Default defines settings for all indices. To configure different settings
     # for a single index  simply add a corresponding definition with the index name 
     # ('Customer', 'CustomerUser' or 'Ticket') instead of 'Default'.
-    $Self->{'Elasticsearch::IndexSettings'} = {
-        Default => {
-            'NS'          => '1',
-            'NR'          => '0',
-        }
-    };
+    # NOTE: This setting will be activated in future versions
+    #$Self->{'Elasticsearch::IndexSettings'} = {
+    #    Default => {
+    #        'NS'          => '1',
+    #        'NR'          => '0',
+    #    }
+    #};
 
     # Elasticsearch index definition template
     # To use a different index template for just one index add a corresponding


### PR DESCRIPTION
Comment out a setting in Defaults.pm that is not activated yet in system configuration. This prevents a test in scripts/test/Config/Defaults.t from failing.