### PR TITLE
Issue #1211: do not redeclare %CustomerUserList

### DIFF
--- a/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
+++ b/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
@@ -323,7 +323,7 @@ sub MigrateCustomerUsers {
 
     # No special search, search all customers together
     if ( $CustomerLimitLevel == 0 ) {
-        my %CustomerUserList = $CustomerUserObject->CustomerSearch(
+        %CustomerUserList = $CustomerUserObject->CustomerSearch(
             Search => '*',
             Valid  => 1,
             Limit  => 4_000_000,

--- a/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
+++ b/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
@@ -67,6 +67,7 @@ sub Configure {
         HasValue   => 1,
         ValueRegex => qr/^\d$/smx,
     );
+
     return;
 }
 
@@ -120,6 +121,7 @@ sub Run {
     # test the connection to the server
     if ( !$ESObject->TestConnection() ) {
         $Self->Print("<red>Connection could not be established!</red>\n");
+
         return 0;
     }
 
@@ -127,13 +129,13 @@ sub Run {
     my $MicroSleep         = $Self->GetOption('micro-sleep');
     my $CustomerLimitLevel = $Self->GetOption('use-customer-batches') || '0';
 
-    if ( $Targets =~ /t|i/ ) {
+    if ( $Targets =~ m/t|i/ ) {
         $Self->CreateAttachmentPipeline(
             ESObject => $ESObject,
         );
     }
 
-    if ( $Targets =~ /c/ ) {
+    if ( $Targets =~ m/c/ ) {
         $Self->MigrateCompanies(
             ESObject => $ESObject,
             Config   => $ConfigIndexSettings->{Customer} // $Config,
@@ -215,6 +217,7 @@ sub CreateAttachmentPipeline {
     }
     else {
         $Self->Print("<red>Attachment pipeline could not be set up!</red>\n");
+
         return 0;
     }
 
@@ -275,11 +278,12 @@ sub MigrateCompanies {
     # return if no StoreFields are defined
     if ( !$Kernel::OM->Get('Kernel::Config')->Get('Elasticsearch::CustomerCompanyStoreFields') ) {
         $Self->Print("<yellow>No CustomerCompanyStoreFields are defined.</yellow>\n");
+
         return 1;
     }
 
     my $Count         = 0;
-    my $CustomerCount = scalar( keys %CustomerCompanyList );
+    my $CustomerCount = scalar keys %CustomerCompanyList;
 
     my $Errors = 0;
     CUSTOMERID:
@@ -311,7 +315,6 @@ sub MigrateCompanies {
     }
 
     return 1;
-
 }
 
 sub MigrateCustomerUsers {
@@ -388,6 +391,7 @@ sub MigrateCustomerUsers {
     }
     else {
         $Self->Print("<red>CustomerUser index could not be created!</red>\n");
+
         return 0;
     }
 
@@ -398,7 +402,7 @@ sub MigrateCustomerUsers {
     }
 
     my $Count             = 0;
-    my $CustomerUserCount = scalar( keys %CustomerUserList );
+    my $CustomerUserCount = scalar keys %CustomerUserList;
 
     my $Errors = 0;
     CUSTOMERUSERID:
@@ -430,7 +434,6 @@ sub MigrateCustomerUsers {
     }
 
     return 1;
-
 }
 
 sub MigrateTickets {
@@ -497,12 +500,14 @@ sub MigrateTickets {
     }
     else {
         $Self->Print("<red>Ticket index could not be created!</red>\n");
+
         return 0;
     }
 
     # return if no StoreFields are defined
     if ( !$Kernel::OM->Get('Kernel::Config')->Get('Elasticsearch::TicketStoreFields') ) {
         $Self->Print("<yellow>No TicketStoreFields are defined.</yellow>\n");
+
         return 1;
     }
 
@@ -560,7 +565,6 @@ sub MigrateTickets {
     }
 
     return 1;
-
 }
 
 sub MigrateConfigItems {
@@ -573,6 +577,7 @@ sub MigrateConfigItems {
     );
     if ( !$IsInstalled ) {
         $Self->Print("<green>Skipping ITSMConfigItems (ITSMConfigurationManagment not installed)...</green>\n");
+
         return 1;
     }
 
@@ -639,12 +644,14 @@ sub MigrateConfigItems {
     }
     else {
         $Self->Print("<red>ConfigItem index could not be created!</red>\n");
+
         return 0;
     }
 
     # return if no StoreFields are defined
     if ( !$Kernel::OM->Get('Kernel::Config')->Get('Elasticsearch::ConfigItemStoreFields') ) {
         $Self->Print("<yellow>No ConfigItemStoreFields are defined.</yellow>\n");
+
         return 1;
     }
 
@@ -656,7 +663,7 @@ sub MigrateConfigItems {
     );
 
     my $Count   = 0;
-    my $CICount = scalar( @{$ConfigItems} );
+    my $CICount = scalar @{$ConfigItems};
 
     my $Errors = 0;
     for my $ConfigItemID ( @{$ConfigItems} ) {
@@ -687,7 +694,6 @@ sub MigrateConfigItems {
     }
 
     return 1;
-
 }
 
 1;

--- a/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
+++ b/Kernel/System/Console/Command/Maint/Elasticsearch/Migration.pm
@@ -311,7 +311,7 @@ sub MigrateCompanies {
         $Self->Print("<yellow>CustomerCompany transfer complete. $Errors error(s) occured!</yellow>\n");
     }
     else {
-        $Self->Print("<green>CustomerCompany transfer complete.</green>\n");
+        $Self->Print("<green>CustomerCompany transfer complete. Transferred $Count companies.</green>\n");
     }
 
     return 1;
@@ -430,7 +430,7 @@ sub MigrateCustomerUsers {
         $Self->Print("<yellow>CustomerUser transfer complete. $Errors error(s) occured!</yellow>\n");
     }
     else {
-        $Self->Print("<green>CustomerUser transfer complete.</green>\n");
+        $Self->Print("<green>CustomerUser transfer complete. Transferred $Count customer users.</green>\n");
     }
 
     return 1;
@@ -561,7 +561,7 @@ sub MigrateTickets {
         $Self->Print("<yellow>Ticket transfer complete. $Errors error(s) occured!</yellow>\n");
     }
     else {
-        $Self->Print("<green>Ticket transfer complete.</green>\n");
+        $Self->Print("<green>Ticket transfer complete. Transferred $Count tickets.</green>\n");
     }
 
     return 1;
@@ -690,7 +690,7 @@ sub MigrateConfigItems {
         $Self->Print("<yellow>ConfigItem transfer complete. $Errors error(s) occured!</yellow>\n");
     }
     else {
-        $Self->Print("<green>ConfigItem transfer complete.</green>\n");
+        $Self->Print("<green>ConfigItem transfer complete. Transferred $Count config items.</green>\n");
     }
 
     return 1;


### PR DESCRIPTION
Hi @StefanRother-OTOBO ,

it looks like %CustomerUserList was redeclared in the inner scope that is used when the limit is 0.
could you test this patch in your next ElasticSearch-Migration ? 