### PR TITLE
Issue #1216: Maint::Config::Rebuild is needed after all,

### DIFF
--- a/Kernel/System/MigrateFromOTRS/OTOBOMigrateConfigFromOTRS.pm
+++ b/Kernel/System/MigrateFromOTRS/OTOBOMigrateConfigFromOTRS.pm
@@ -198,8 +198,9 @@ sub Run {
         return {
             Message => $Self->{LanguageObject}->Translate("Migrate configuration settings."),
             Comment => $Self->{LanguageObject}->Translate(<<'END_COMMENT'),
-The merged configuration could not be deployed because it contain invalid values. Please try to fix the configuration
+The merged configuration could not be deployed because it contains invalid values. Please try to fix the configuration
 by running these commands: "bin/otobo.Console.pl Admin::Config::ListInvalid" and "bin/otobo.Console.pl Admin::Config::FixInvalid".
+After fixing the configuration run "bin/otobo.Console.pl Maint::Config::Rebuild" and continue with the migration.
 END_COMMENT
             Successful => 0,
         };


### PR DESCRIPTION
especially when SecureMode was active in the source OTRS installation.