### PR TITLE
Russian translate fixed: 'customers => клиенты' replaced by 'customer…

### DIFF
--- a/Kernel/Language/ru.pm
+++ b/Kernel/Language/ru.pm
@@ -444,7 +444,7 @@ sub Data {
         'If nothing is selected, then there are no permissions in this group (tickets will not be available for the customer).' =>
             'Если ничего не выбрано, тогда у клиентов в этой группе не будет прав (заявки будут недоступны клиенту).',
         'Search Results' => 'Результаты поиска',
-        'Customers' => 'Клиенты',
+        'Customers' => 'Компании',
         'Groups' => 'Группы',
         'Change Group Relations for Customer' => 'Изменить связи групп с клиентами',
         'Change Customer Relations for Group' => 'Изменить связь клиентов с группой',


### PR DESCRIPTION
Russian translate fixed: 'customers => клиенты' replaced by 'customers => компании in order to make 'Customers' and 'Customer users' translate different and more correct

**Old translation:**
Customers => Клиенты
Customer users => Клиенты

**Fixed translation**
Customers => Компании
Customer users => Клиенты