### PR TITLE
Issue #772: Headers was a hash ref in 10.0.x

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -663,14 +663,14 @@ sub RequesterPerformRequest {
     }
 
     if ( $Param{CustomHeader} ) {
-        $Headers = {
-            %{$Headers},
+        %Headers = (
+            %Headers,
             %{ $Param{CustomHeader} },
-        };
+        );
 
         $Self->{DebuggerObject}->Debug(
             Summary => "Custom headers used (might overwrite authorization)",
-            Data    => join( '; ', keys %{ $Param{CustomHeader} } ),
+            Data    => join( '; ', keys $Param{CustomHeader}->%* ),
         );
     }
 


### PR DESCRIPTION
but has been changed to a hash in 10.1.x