### PR TITLE
Issue #1434 browser

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -209,7 +209,7 @@ EOF
     $Self->{FilterText} = $ConfigObject->Get('Frontend::Output::FilterText');
 
     # check browser features relying on the user agent as transmitted by the client
-    $Self->{Platform} = '';
+    my $Platform = '';
     $Self->{IsMobile} = 0;
 
     $Self->{BrowserJavaScriptSupport} = 1;
@@ -232,7 +232,7 @@ EOF
 
         # android
         if ( $HttpUserAgent =~ /android/ ) {
-            $Self->{Platform} = 'Android';
+            $Platform = 'Android';
         }
 
         # edge / spartan
@@ -256,13 +256,13 @@ EOF
 
             # older windows mobile phones (until IE9), that still have 'MSIE' in the user agent string
             if ( $Self->{IsMobile} ) {
-                $Self->{Platform} = 'Windows Phone';
+                $Platform = 'Windows Phone';
             }
         }
 
         # mobile ie
         elsif ( $HttpUserAgent =~ /iemobile/ ) {
-            $Self->{Platform} = 'Windows Phone';
+            $Platform = 'Windows Phone';
         }
 
         # mobile ie (second try)
@@ -276,7 +276,7 @@ EOF
 
         # iOS
         elsif ( $HttpUserAgent =~ /(ipad|iphone|ipod)/ ) {
-            $Self->{Platform} = 'iOS';
+            $Platform = 'iOS';
 
             my $BrowserVersion = 0;
             if ( $HttpUserAgent =~ /(ipad|iphone|ipod);.*cpu.*os ([0-9]+)_/ ) {
@@ -346,9 +346,9 @@ EOF
     # check mobile devices to disable richtext support
     if (
         $Self->{IsMobile}
-        && $Self->{Platform} ne 'iOS'
-        && $Self->{Platform} ne 'Android'
-        && $Self->{Platform} ne 'Windows Phone'
+        && $Platform ne 'iOS'
+        && $Platform ne 'Android'
+        && $Platform ne 'Windows Phone'
         )
     {
         $Self->{BrowserRichText} = 0;


### PR DESCRIPTION
Hi @svenoe , @stefanhaerter ,

what do you think of this PR? Eliminating unneeded attribtutes in the layout object is safe for core OTOBO, But any package could have used any of the removed attributes. On the other hand, accessing attributes is not part of the documented interface.