### PR TITLE
add new events wrt email transmission errors

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -10871,6 +10871,8 @@
                 <Item>ArticleEmailSendingQueued</Item>
                 <Item>ArticleEmailSendingSent</Item>
                 <Item>ArticleEmailSendingError</Item>
+                <Item>ArticleTransmissionErrorCreate</Item>
+                <Item>ArticleTransmissionErrorUpdate</Item>
             </Array>
         </Value>
     </Setting>

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -817,6 +817,21 @@ sub ArticleCreateTransmissionError {
         Bind => \@Bind,
     );
 
+    my $ArticleObject = $Kernel::OM->Get('Kernel::System::Ticket::Article');
+    my $TicketID      = $ArticleObject->TicketIDLookup(
+        ArticleID => $Param{ArticleID},
+    );
+
+    # event
+    $Self->EventHandler(
+        Event => 'ArticleTransmissionErrorCreate',
+        Data  => {
+            ArticleID => $Param{ArticleID},
+            TicketID  => $TicketID,
+        },
+        UserID => $Param{UserID} || 1,
+    );
+
     return 1;
 }
 
@@ -934,6 +949,21 @@ sub ArticleUpdateTransmissionError {
     return if !$Kernel::OM->Get('Kernel::System::DB')->Do(
         SQL  => $SQL,
         Bind => \@Bind,
+    );
+
+    my $ArticleObject = $Kernel::OM->Get('Kernel::System::Ticket::Article');
+    my $TicketID      = $ArticleObject->TicketIDLookup(
+        ArticleID => $Param{ArticleID},
+    );
+
+    # event
+    $Self->EventHandler(
+        Event => 'ArticleTransmissionErrorUpdate',
+        Data  => {
+            ArticleID => $Param{ArticleID},
+            TicketID  => $TicketID,
+        },
+        UserID => $Param{UserID} || 1,
     );
 
     return 1;


### PR DESCRIPTION
Until now, no one notices when a transmission error occurs and the ticket
is closed. With the new events it is possible to create GenericAgent jobs
that listens for the transmission error events and tickets can be re-opened
automatically.