### PR TITLE
Issue #1462: set auth_gss_keytab to the value /etc/krb5.keytab

### DIFF
--- a/scripts/nginx/templates/otobo_nginx.conf.template
+++ b/scripts/nginx/templates/otobo_nginx.conf.template
@@ -44,10 +44,10 @@ server {
     # proxy to the otobo webapp accessible from the host
     # pass on information about the client
     location / {
-	# Example to use Kerberos SSO 
+	# Example to use Kerberos SSO
 	# proxy_set_header REMOTE_USER $remote_user;
 	# auth_gss on;
-	# auth_gss_keytab ${OTOBO_NGINX_KERBEROS_KEYTAB};
+	# auth_gss_keytab /etc/krb5.keytab
 	# auth_gss_service_name ${OTOBO_NGINX_KERBEROS_SERVICE_NAME};
 	# auth_gss_realm ${OTOBO_NGINX_KERBEROS_REALM};
 	# auth_gss_allow_basic_fallback on;


### PR DESCRIPTION
No need to make this configurable. The file /etc/krb5.keytab usually resides
on the Docker host and is mounted into the exact location.