### PR TITLE
integrate dashboard mylastchangedtickets addon

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -6594,6 +6594,31 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
+    <Setting Name="DashboardBackend###0322-MyLastChangedTickets" Required="0" Valid="1">
+        <Description Translatable="1">MyLastChangedTickets dashboard widget.</Description>
+        <Navigation>Frontend::Agent::View::Dashboard</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::Dashboard::MyLastChangedTickets</Item>
+                <Item Key="Title" Translatable="1">My last changed tickets</Item>
+                <Item Key="Permission">rw</Item>
+                <Item Key="OwnerOnly"></Item>
+                <Item Key="Block">ContentSmall</Item>
+                <Item Key="Limit">6</Item>
+                <Item Key="Group"></Item>
+                <Item Key="Default">1</Item>
+                <Item Key="CacheTTL">2</Item>
+                <Item Key="Mandatory">0</Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="DashboardMyLastChangedTickets::Limit" Required="1" Valid="1">
+        <Description Translatable="1">Defines the number of tickets shown in the widget.</Description>
+        <Navigation>Frontend::Agent::View::Dashboard::MyLastChangedTickets</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="^\d+$">10</Item>
+        </Value>
+    </Setting>
     <Setting Name="AgentCustomerInformationCenter::Backend###0050-CIC-CustomerUserList" Required="0" Valid="1">
         <Description Translatable="1">Parameters for the dashboard backend of the customer user list overview of the agent interface . "Limit" is the number of entries shown by default. "Group" is used to restrict the access to the plugin (e. g. Group: admin;group1;group2;). "Default" determines if the plugin is enabled by default or if the user needs to enable it manually. "CacheTTLLocal" is the cache time in minutes for the plugin.</Description>
         <Navigation>Frontend::Agent::View::CustomerInformationCenter</Navigation>

--- a/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
+++ b/Kernel/Output/HTML/Dashboard/MyLastChangedTickets.pm
@@ -1,0 +1,163 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2019-2021 Rother OSS GmbH, https://otobo.de/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+package Kernel::Output::HTML::Dashboard::MyLastChangedTickets;
+
+use strict;
+use warnings;
+
+use Kernel::Language qw(Translatable);
+
+our $ObjectManagerDisabled = 1;
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # allocate new hash for object
+    my $Self = {%Param};
+    bless( $Self, $Type );
+
+    # get needed objects
+    for my $Needed (qw(Config Name UserID)) {
+        die "Got no $Needed!" if ( !$Self->{$Needed} );
+    }
+
+    # check if the user has filter preferences for this widget
+    my %Preferences = $Kernel::OM->Get('Kernel::System::User')->GetPreferences(
+        UserID => $Self->{UserID},
+    );
+
+    $Self->{PrefKeyShown}   = 'UserDashboardPref' . $Self->{Name} . '-Shown';
+    $Self->{PageShown}      = $Preferences{ $Self->{PrefKeyShown} };
+
+    return $Self;
+}
+
+sub Preferences {
+    my ( $Self, %Param ) = @_;
+
+    my @Params = (
+        {
+            Desc  => Translatable('Shown Tickets'),
+            Name  => $Self->{PrefKeyShown},
+            Block => 'Option',
+            Data  => {
+                5  => ' 5',
+                10 => '10',
+                15 => '15',
+                20 => '20',
+                25 => '25',
+                30 => '30',
+                35 => '35',
+            },
+            SelectedID  => $Self->{PageShown},
+            Translation => 0,
+        },
+    );
+
+    return @Params;
+}
+
+sub Config {
+    my ( $Self, %Param ) = @_;
+
+    return (
+        %{ $Self->{Config} },
+        CacheKey => 'MyLastChangedTickets'
+            . $Self->{UserID} . '-'
+            . $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{UserLanguage},
+    );
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
+    my $UserObject   = $Kernel::OM->Get('Kernel::System::User');
+    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    my $UseRefresh = $ConfigObject->Get('DashboardMyLastChangedTickets::UseRefresh');
+    if ( $UseRefresh ) {
+        $LayoutObject->Block(
+            Name => 'Refresh',
+            Data => {
+                Name => $Self->{Name},
+            },
+        );
+    }
+
+    my %Preferences = $UserObject->GetPreferences(
+        UserID => $Self->{UserID},
+    );
+
+    my $UserLimit = $Preferences{ $Self->{PrefKeyShown} };
+    my $Limit     = $UserLimit || $ConfigObject->Get( 'DashboardMyLastChangedTickets::Limit' );
+
+    my $SQL = qq~
+        SELECT ticket_id, MAX(change_time) max_t
+        FROM ticket_history
+        WHERE change_by = ?
+        GROUP BY ticket_id
+        ORDER BY max_t desc
+    ~;
+
+    return if !$DBObject->Prepare(
+        SQL   => $SQL,
+        Bind  => [ \$Self->{UserID} ],
+        Limit => $Limit,
+    );
+
+    my @TicketIDs;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        push @TicketIDs, $Row[0];
+    }
+
+    if ( !@TicketIDs ) {
+        $LayoutObject->Block(
+            Name => 'NoTickets',
+        );
+    }
+    else {
+        for my $TicketID ( @TicketIDs ) {
+            my %Ticket = $TicketObject->TicketGet(
+                TicketID => $TicketID,
+                UserID   => $Self->{UserID},
+            );
+
+            $Ticket{Link} = "Action=AgentTicketZoom&TicketID=$TicketID";
+
+            $LayoutObject->Block(
+                Name => 'Ticket',
+                Data => \%Ticket,
+            );
+        }
+    }
+
+    # render content
+    my $Content = $LayoutObject->Output(
+        TemplateFile => 'AgentDashboardMyLastChangedTickets',
+        Data         => {
+            %{ $Self->{Config} },
+        },
+    );
+
+    # return content
+    return $Content;
+}
+
+1;
+

--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardMyLastChangedTickets.tt
@@ -1,0 +1,35 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2019-2021 Rother OSS GmbH, https://otobo.de/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+<div id="mylastchangedtickets-data">
+<table class="DataTable">
+    <tbody>
+[% RenderBlockStart("Ticket") %]
+        <tr>
+            <td>
+                <a href="[% Env("Baselink") %][% Data.Link %]" title="[% Data.Title | html %]">[% Data.TicketNumber %]</a> [% Data.Title | truncate(50) | html %]
+            </td>
+        </tr>
+[% RenderBlockEnd("Ticket") %]
+[% RenderBlockStart("NoTickets") %]
+        <tr>
+            <td>
+                [% Translate("No tickets found.") | html %]
+            </td>
+        </tr>
+[% RenderBlockEnd("NoTickets") %]
+    </tbody>
+</table>
+</div>


### PR DESCRIPTION
## Proposed change

This PR integrates the OPAR addon DashboardMyLastChangedTickets into Znuny.
It adds a dashboard widget where agents get a list of tickets that they changed.

![grafik](https://user-images.githubusercontent.com/144096/145614649-7ebc9e5f-d7a5-487b-9be1-33c77e7f9c4b.png)

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Info

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
