### PR TITLE
add customer ticketcategories service and state

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -1925,6 +1925,43 @@
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="Ticket::Frontend::CustomerTicketCategories###State" Required="0" Valid="0">
+        <Description Translatable="1">Categories used in ticket presentation. Order is only used to determine the starting position before size arrangement. If no default color is given, item will not be shown if selection is not defined in the color hash.</Description>
+        <Navigation>Frontend::Customer::TicketCategories</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="Order">1</Item>
+                <Item Key="Prefix"></Item>
+                <Item Key="ColorDefault">#337777</Item>
+                <Item Key="ColorSelection">
+                    <Hash>
+                        <Item Key="open">#bb2222</Item>
+                        <Item Key="new">#887733</Item>
+                        <Item Key="closed successful">#0033cc</Item>
+                    </Hash>
+                </Item>
+
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Ticket::Frontend::CustomerTicketCategories###Service" Required="0" Valid="0">
+        <Description Translatable="1">Categories used in ticket presentation. Order is only used to determine the starting position before size arrangement. If no default color is given, item will not be shown if selection is not defined in the color hash.</Description>
+        <Navigation>Frontend::Customer::TicketCategories</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="Order">1</Item>
+                <Item Key="Prefix"></Item>
+                <Item Key="ColorDefault">#337777</Item>
+                <Item Key="ColorSelection">
+                    <Hash>
+                        <Item Key="Service1">#bb2222</Item>
+                        <Item Key="Service2">#887733</Item>
+                        <Item Key="Service3">#0033cc</Item>
+                    </Hash>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::Frontend::CustomerTicketCategories###DynamicField###010" Required="0" Valid="0">
         <Description Translatable="1">Categories used in ticket presentation. If no default color is given, item will not be shown if selection is not defined in the color hash.</Description>
         <Navigation>Frontend::Customer::TicketCategories</Navigation>

--- a/Kernel/Output/HTML/TicketOverview/CustomerList.pm
+++ b/Kernel/Output/HTML/TicketOverview/CustomerList.pm
@@ -182,7 +182,7 @@ sub Run {
 
         # standard ticket categories
         CAT:
-        for my $CatName (qw/Queue Owner/) {
+        for my $CatName (qw/Queue Owner State Service/) {
             next CAT if !$Ticket{$CatName};
             if ( $CategoryConfig->{$CatName} ) {
                 my $Conf = $CategoryConfig->{$CatName};


### PR DESCRIPTION
## Proposed change

Enable service and state as possible ticket categories in the customer frontend. Ticket categories are the preferred way to show additional ticket information in the ticket overview.

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Info

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
