### PR TITLE
Issue #1500: load Time::HiRes() before using a function from Time::Res()

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationComplex.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationComplex.t
@@ -18,14 +18,17 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+use Time::HiRes qw();
 
-use vars (qw($Self));
+# CPAN modules
 
-# get selenium object
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 my @Tests = (

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleArray.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleArray.t
@@ -18,13 +18,17 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+use Time::HiRes qw();
 
-use vars (qw($Self));
+# CPAN modules
 
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 my @Tests = (

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleBasic.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleBasic.t
@@ -18,13 +18,17 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+use Time::HiRes qw();
 
-use vars (qw($Self));
+# CPAN modules
 
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 my @Tests = (

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleHash.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleHash.t
@@ -18,13 +18,17 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+use Time::HiRes qw();
 
-use vars (qw($Self));
+# CPAN modules
 
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 my @Tests = (

--- a/scripts/test/SysConfig/RebuildConfigBug14259.t
+++ b/scripts/test/SysConfig/RebuildConfigBug14259.t
@@ -18,10 +18,15 @@ use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
+# core modules
+use Time::HiRes qw();
 
-use vars (qw($Self));
+# CPAN modules
+
+# OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
+
+our $Self;
 
 my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 


### PR DESCRIPTION
Only led to one error in RebuildConfigBug14259.t, likely because in the other cases
some other module did load Time::HiRes.