### PR TITLE
one can define more than just the default 9 calendars.

### DIFF
--- a/Kernel/System/SupportDataCollector/Plugin/OTOBO/TimeSettings.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OTOBO/TimeSettings.pm
@@ -85,7 +85,14 @@ sub Run {
     }
 
     # Calendar time zones
-    for my $Counter ( 1 .. 9 ) {
+    my $Maximum = $ConfigObject->Get("MaximumCalendarNumber") || 50;
+
+    COUNTER:
+    for my $Counter ( '', 1 .. $Maximum ) {
+        my $CalendarName = $ConfigObject->Get('TimeZone::Calendar' . $Counter . 'Name' );
+
+        next COUNTER if !$CalendarName;
+
         my $CalendarTimeZone = $ConfigObject->Get( 'TimeZone::Calendar' . $Counter );
 
         if ( defined $CalendarTimeZone ) {


### PR DESCRIPTION
 In AdminSLA and AdminQueue this is already implemented, but not in the support data collector