### PR TITLE
[#1339] Do not update subqueues when the name was not changed

### DIFF
--- a/Kernel/System/Queue.pm
+++ b/Kernel/System/Queue.pm
@@ -1226,6 +1226,8 @@ sub QueueUpdate {
         Type => $Self->{CacheType},
     );
 
+    return 1 if $Param{Name} eq $OldQueue{Name};
+
     # updated all sub queue names
     my @ParentQueue = split( /::/, $OldQueue{Name} );
 


### PR DESCRIPTION
An update of the parent queue did **always** update the names of the subqueues even when the name wasn't changed.

This PR can be extended when a name update shouldn't change the "last updated" timestamp of the subqueues either.