### PR TITLE
[#1266] the number 0 is a pretty valid value for dropdown fields ;-)

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -365,7 +365,7 @@ sub EditFieldValueValidate {
     my $ErrorMessage;
 
     # perform necessary validations
-    if ( $Param{Mandatory} && !$Value ) {
+    if ( $Param{Mandatory} && !( defined $Value && length $Value ) ) {
         return {
             ServerError => 1,
         };

--- a/Kernel/System/DynamicField/Driver/Multiselect.pm
+++ b/Kernel/System/DynamicField/Driver/Multiselect.pm
@@ -471,7 +471,7 @@ sub EditFieldValueGet {
         ITEM:
         for my $Item ( sort @Data ) {
 
-            if ( !$Item ) {
+            if ( !defined $Item || !length $Item ) {
                 splice( @Data, $Index, 1 );
                 next ITEM;
             }
@@ -524,7 +524,7 @@ sub EditFieldValueValidate {
 
         # validate if value is in possible values list (but let pass empty values)
         for my $Item ( @{$Values} ) {
-            if ( !$PossibleValues->{$Item} ) {
+            if ( !exists $PossibleValues->{$Item} ) {
                 $ServerError  = 1;
                 $ErrorMessage = 'The field content is invalid';
             }
@@ -575,11 +575,11 @@ sub DisplayValueRender {
 
     VALUEITEM:
     for my $Item (@Values) {
-        next VALUEITEM if !$Item;
+        next VALUEITEM if !defined $Item;
 
         my $ReadableValue = $Item;
 
-        if ( $PossibleValues->{$Item} ) {
+        if ( defined $PossibleValues->{$Item} ) {
             $ReadableValue = $PossibleValues->{$Item};
             if ($TranslatableValues) {
                 $ReadableValue = $Param{LayoutObject}->{LanguageObject}->Translate($ReadableValue);


### PR DESCRIPTION
Currently the code checks for _true_-ness of the values set. But in Perl
the number 0 is _false_. It should be a valid value though. This commit
changes some checks so that _defined_-ness and length is checked. As 0 is
_defined_ and has a length it is treated as a valid value.

This PR **shouldn't** be merged until the unit tests show that it is safe ;-)