### PR TITLE
translate state and service when used as a category ...

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/CustomerList.pm
+++ b/Kernel/Output/HTML/TicketOverview/CustomerList.pm
@@ -187,6 +187,10 @@ sub Run {
             if ( $CategoryConfig->{$CatName} ) {
                 my $Conf = $CategoryConfig->{$CatName};
 
+                if ( $CatName eq 'State' || $CatName eq 'Service' ) {
+                    $Ticket{$CatName} = $LayoutObject->{LanguageObject}->Translate( $Ticket{$CatName} );
+                }
+
                 if ( $Conf->{ColorSelection}{ $Ticket{$CatName} } ) {
                     push @{ $Categories{ $Conf->{Order} } }, {
                         Text  => $Conf->{Prefix} ? "$Conf->{Prefix} $Ticket{ $CatName }" : $Ticket{$CatName},


### PR DESCRIPTION
…in the customer ticket overview

The PR #1498 added ticket state and service as a category in the customer ticket overview. But it didn't translate the values.