### PR TITLE
Add missing semikolon

### DIFF
--- a/scripts/nginx/templates/otobo_nginx-kerberos.conf.template
+++ b/scripts/nginx/templates/otobo_nginx-kerberos.conf.template
@@ -48,7 +48,7 @@ server {
         # Settings for useing Kerberos SSO (mostly untested)
         proxy_set_header REMOTE_USER $remote_user;
         auth_gss on;
-        auth_gss_keytab /etc/krb5.keytab
+        auth_gss_keytab /etc/krb5.keytab;
         auth_gss_service_name ${OTOBO_NGINX_KERBEROS_SERVICE_NAME};
         auth_gss_realm ${OTOBO_NGINX_KERBEROS_REALM};
         auth_gss_allow_basic_fallback on;


### PR DESCRIPTION
See #1476.
Probably the docker images have to be rebuilt to fix this issue 'in the wild'.