### PR TITLE
show packages from the 'default' repository even when the user didn't…

### DIFF
--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -1526,8 +1526,17 @@ sub Run {
     #   in the layout block.
     my @RepositoryList = $PackageObject->RepositoryList();
 
+    my %AllRepositories = (
+        %List,
+        %RepositoryRoot,
+	%{ $RepositoryCloudList },
+    );
+
+    $Source ||= (sort { $a cmp $b } keys %AllRepositories)[0];
+    Kernel::LOG( $Source );
+
     $Frontend{SourceList} = $LayoutObject->BuildSelection(
-        Data        => { %List, %RepositoryRoot, %{$RepositoryCloudList}, },
+        Data        => \%AllRepositories,
         Name        => 'Source',
         Title       => Translatable('Repository List'),
         Max         => 40,

--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -1533,7 +1533,6 @@ sub Run {
     );
 
     $Source ||= (sort { $a cmp $b } keys %AllRepositories)[0];
-    Kernel::LOG( $Source );
 
     $Frontend{SourceList} = $LayoutObject->BuildSelection(
         Data        => \%AllRepositories,


### PR DESCRIPTION
… explicitly clicked 'Update repository information'

"Default" means the first repository in the list.

That makes admins life easier as he/she gets information about new/updated addons in the default repository.
