### PR TITLE
Show parameters of transition actions

### DIFF
--- a/Kernel/Config/Files/XML/ProcessManagement.xml
+++ b/Kernel/Config/Files/XML/ProcessManagement.xml
@@ -240,6 +240,7 @@
                 <Item Key="JavaScript">
                     <Array>
                         <Item>Core.Agent.Admin.ProcessManagement.js</Item>
+                        <Item>Core.Agent.Admin.ProcessManagement.TransitionActionParameters.js</Item>
                     </Array>
                 </Item>
             </Hash>
@@ -644,6 +645,16 @@
                 <Item ValueType="Option" Value="CustomerTicketOverview" Translatable="1">Customer ticket overview</Item>
                 <Item ValueType="Option" Value="CustomerTicketZoom" Translatable="1">Customer ticket zoom</Item>
             </Item>
+        </Value>
+    </Setting>
+   <Setting Name="TransitionActionParams::SetOptionalParameters" Required="0" Valid="1">
+        <Description Translatable="1">
+            Show optional parameters in parameter list, too. If disabled, the optional parameters are only shown
+            in an extra table
+        </Description>
+        <Navigation>Frontend::Admin::View::AdminProcessManagement</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
 </otobo_config>

--- a/Kernel/System/ProcessManagement/TransitionAction/DynamicFieldSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/DynamicFieldSet.pm
@@ -58,6 +58,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Fieldname (replace with the real fieldname)',
+            Value => 'New value (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketArticleCreate.pm
@@ -62,6 +62,83 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'CommunicationChannel',
+            Value => 'Email|Phone|Internal (required)',
+        },
+        {
+            Key      => 'From',
+            Value    => 'agent@example.tld',
+            Optional => 1,
+        },
+        {
+            Key      => 'To',
+            Value    => 'customer@example.tld',
+            Optional => 1,
+        },
+        {
+            Key   => 'Subject',
+            Value => 'A subject (required)',
+        },
+        {
+            Key   => 'Body',
+            Value => 'A text for the article (required)',
+        },
+        {
+            Key   => 'ContentType',
+            Value => 'text/html; charset=utf-8 (required)',
+        },
+        {
+            Key   => 'IsVisibleForCustomer',
+            Value => '0|1 (required)',
+        },
+        {
+            Key      => 'DynamicField_<Name> (replace <Name>)',
+            Value    => 'A value',
+            Optional => 1,
+        },
+        {
+            Key   => 'HistoryType',
+            Value => 'EmailCustomer|AddNote|WebRequestCustomer|... (required)',
+        },
+        {
+            Key   => 'HistoryComment',
+            Value => 'Article created (required)',
+        },
+        {
+            Key   => 'SenderType',
+            Value => 'agent|customer|system (required)',
+        },
+        {
+            Key      => 'UnlockOnAway',
+            Value    => '0|1',
+            Optional => 1,
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );  
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
@@ -65,6 +65,162 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Title',
+            Value => 'A title (required)',
+        },
+        {
+            Key   => 'CommunicationChannel',
+            Value => 'Email|Phone|Internal (required)',
+        },
+        {
+            Key      => 'From',
+            Value    => 'agent@example.tld',
+            Optional => 1,
+        },
+        {
+            Key      => 'To',
+            Value    => 'customer@example.tld',
+            Optional => 1,
+        },
+        {
+            Key   => 'Subject',
+            Value => 'A subject (required)',
+        },
+        {
+            Key   => 'Body',
+            Value => 'A text for the article (required)',
+        },
+        {
+            Key   => 'ContentType',
+            Value => 'text/html; charset=utf-8 (required)',
+        },
+        {
+            Key      => 'CustomerID',
+            Value    => '12345',
+            Optional => 1,
+        },
+        {
+            Key      => 'CustomerUser',
+            Value    => 'customer@example.tld',
+            Optional => 1,
+        },
+        {
+            Key   => 'IsVisibleForCustomer',
+            Value => '0|1 (required)',
+        },
+        {
+            Key      => 'DynamicField_<Name> (replace <Name>)',
+            Value    => 'A value',
+            Optional => 1,
+        },
+        {
+            Key      => 'Attachments',
+            Value    => '...',
+            Optional => 1,
+        },
+        {
+            Key   => 'State',
+            Value => 'open (required)',
+        },
+        {
+            Key   => 'Lock',
+            Value => 'lock|unlock (required)',
+        },
+        {
+            Key   => 'Owner',
+            Value => 'ownerlogin (required)',
+        },
+        {
+            Key   => 'Priority',
+            Value => '3 normal (required)',
+        },
+        {
+            Key   => 'Queue',
+            Value => 'Misc (required)',
+        },
+        {
+            Key      => 'Type',
+            Value    => 'A type',
+            Optional => 1,
+        },
+        {
+            Key      => 'Service',
+            Value    => 'ServiceName',
+            Optional => 1,
+        },
+        {
+            Key      => 'SLA',
+            Value    => 'SLA-Name',
+            Optional => 1,
+        },
+        {
+            Key      => 'Responsible',
+            Value    => 'responsiblelogin',
+            Optional => 1,
+        },
+        {
+            Key      => 'TimeUnit',
+            Value    => 'responsiblelogin',
+            Optional => 1,
+        },
+        {
+            Key   => 'HistoryType',
+            Value => 'EmailCustomer|AddNote|WebRequestCustomer|... (required)',
+        },
+        {
+            Key   => 'HistoryComment',
+            Value => 'Article created (required)',
+        },
+        {
+            Key   => 'SenderType',
+            Value => 'agent|customer|system (required)',
+        },
+        {
+            Key      => 'PendingTime',
+            Value    => '2022-19-21 14:25:00',
+            Optional => 1,
+        },
+        {
+            Key      => 'PendingTimeDiff',
+            Value    => 'diff in minutes',
+            Optional => 1,
+        },
+        {
+            Key      => 'LinkAs',
+            Value    => 'Normal|Parent|Child|...',
+            Optional => 1,
+        },
+        {
+            Key      => 'ArchiveFlag',
+            Value    => 'y|n',
+            Optional => 1,
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketCustomerSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketCustomerSet.pm
@@ -57,6 +57,39 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'CustomerID',
+            Value => '1234 (required - or CustomerUserID)',
+        },
+        {
+            Key   => 'CustomerUserID',
+            Value => 'a_customer (required - or CustomerID)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketLockSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketLockSet.pm
@@ -57,6 +57,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Lock',
+            Value => 'lock|unlock (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketOwnerSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketOwnerSet.pm
@@ -57,6 +57,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Owner',
+            Value => 'a_user_login (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketQueueSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketQueueSet.pm
@@ -57,6 +57,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Queue',
+            Value => 'A::Queue::Name (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketResponsibleSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketResponsibleSet.pm
@@ -58,6 +58,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Responsible',
+            Value => 'a_user_login (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketSLASet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketSLASet.pm
@@ -58,6 +58,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'SLA',
+            Value => 'SLA-Name (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketServiceSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketServiceSet.pm
@@ -59,6 +59,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Service',
+            Value => 'ServiceName (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketStateSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketStateSet.pm
@@ -59,6 +59,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'State',
+            Value => 'a state name (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketTitleSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketTitleSet.pm
@@ -57,6 +57,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Title',
+            Value => 'A new title (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/Kernel/System/ProcessManagement/TransitionAction/TicketTypeSet.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketTypeSet.pm
@@ -58,6 +58,35 @@ sub new {
     return $Self;
 }
 
+=head2 Params()
+
+Returns the configuration params for this transition action module
+
+    my @Params = $Object->Params();
+
+Each element is a hashreference that describes the config parameter.
+Currently only the keys I<Key>, I<Value> and I<Optional> are used.
+
+=cut
+
+sub Params {
+    my ($Self) = @_;
+
+    my @Params = (
+        {
+            Key   => 'Type',
+            Value => 'A new type (required)',
+        },
+        {
+            Key      => 'UserID',
+            Value    => '1 (can overwrite the logged in user)',
+            Optional => 1,
+        },
+    );
+
+    return @Params;
+}
+
 =head2 Run()
 
     Run Data

--- a/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.TransitionActionParameters.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.TransitionActionParameters.js
@@ -1,0 +1,108 @@
+// --
+// Copyright (C) 2021 Perl-Services.de, https://perl-services.de
+// --
+// This software comes with ABSOLUTELY NO WARRANTY. For details, see
+// the enclosed file COPYING for license information (GPL). If you
+// did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
+// --
+
+"use strict";
+
+var Core = Core || {};
+
+Core.Agent = Core.Agent || {};
+Core.Agent.Admin = Core.Agent.Admin || {};
+Core.Agent.Admin.ProcessManagement = Core.Agent.Admin.ProcessManagement || {};
+
+Core.Agent.Admin.ProcessManagement.TransitionActionParameters = (function (TargetNS) {
+    function ClearParameters() {
+        $('#ConfigParams input[name^="ConfigKey"]').each( function ( i, field ) {
+            let $field = $(field);
+            if ( $field.attr('id') === "ConfigKey[1]" ) {
+                return;
+            }
+            $field.parent().remove();
+        });
+        
+        $('#ConfigKey[1]').val('');
+        $('#ConfigValue[1]').val('');
+    }
+
+    function SetParameters ( Module ) {
+        let Data = {
+            TransitionAction: Module,
+            Action: 'AdminProcessManagementTransitionAction',
+            Subaction: 'ActionParams',
+        };
+
+        Core.AJAX.FunctionCall(
+            Core.Config.Get('CGIHandle'),
+            Data,
+            function ( Response ) {
+                var ParameterList = $('<ul></ul>');
+
+                $.each( Response.Params, function ( ParamIndex, Param ) {
+
+                    ParameterList.append(
+                        $('<li></li>').text( Param.Key + ' - ' + Param.Value )
+                    );
+
+                    if ( Response.NoOptionals && Param.Optional ) {
+                        return;
+                    }
+
+                    var ConfigParamHTML;
+
+                    if ( ParamIndex != 0 ) {
+                        ConfigParamHTML = $('#ConfigParamContainer').html().replace(/_INDEX_/g, parseInt(ParamIndex) + 1);
+                    }
+                    else {
+                        ConfigParamHTML = $('#ConfigAdd').closest('.WidgetSimple').find('.Content fieldset').last();
+                    }
+
+                    let $ParamElem = $(ConfigParamHTML);
+            
+                    $ParamElem.find('input[name^="ConfigKey"]').val( Param.Key );
+                    $ParamElem.find('input[name^="ConfigValue"]').attr( 'placeholder', Param.Value );
+
+                    if ( ParamIndex != 0 ) {
+                        let LastField = $('#ConfigAdd').closest('.WidgetSimple').find('.Content fieldset').last();
+                        $ParamElem.insertAfter(LastField);
+                    }
+                });
+
+                $('#ConfigParams').append(
+                    $('<div></div>', { id: 'ParameterList' } )
+                        .append( $('<br>' ) )
+                        .append( $('<h2></h2>').text('All Parameters') )
+                        .append( ParameterList )
+                );
+            }
+        );
+    }
+
+    TargetNS.Init = function() {
+        $('#Module').on('change', function () {
+            let Module = $('#Module option:selected').val();
+
+            // check if user has already filled some parameter fields
+
+
+            // clear parameters
+            ClearParameters();
+            $('#ParameterList').remove();
+
+            if ( !Module || Module === '' ) {
+                return;
+            }
+
+            // request list of parameters
+            SetParameters( Module );
+        });
+    };
+    
+    Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
+
+    return TargetNS;
+}(Core.Agent.Admin.ProcessManagement.TransitionActionParameters || {})); 
+

--- a/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.TransitionActionParameters.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.ProcessManagement.TransitionActionParameters.js
@@ -1,9 +1,16 @@
 // --
-// Copyright (C) 2021 Perl-Services.de, https://perl-services.de
+// OTOBO is a web-based ticketing system for service organisations.
 // --
-// This software comes with ABSOLUTELY NO WARRANTY. For details, see
-// the enclosed file COPYING for license information (GPL). If you
-// did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
+// Copyright (C) 2021-2022 Rother OSS GmbH, https://otobo.de
+// --
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // --
 
 "use strict";
@@ -14,7 +21,23 @@ Core.Agent = Core.Agent || {};
 Core.Agent.Admin = Core.Agent.Admin || {};
 Core.Agent.Admin.ProcessManagement = Core.Agent.Admin.ProcessManagement || {};
 
+/**
+ * @namespace Core.Agent.Admin.ProcessManagement.TransitionActionParameter
+ * @memberof Core.Agent.Admin.ProcessManagement
+ * @author
+ * @description
+ *     This namespace contains the special module functions for the ProcessManagement module.
+ */
 Core.Agent.Admin.ProcessManagement.TransitionActionParameters = (function (TargetNS) {
+
+    /**
+     * @private
+     * @name ClearParameters
+     * @memberof Core.Agent.Admin.ProcessManagement.TransitionActionParameters
+     * @function
+     * @description
+     *      Removes the paremeters in the dalog
+     */
     function ClearParameters() {
         $('#ConfigParams input[name^="ConfigKey"]').each( function ( i, field ) {
             let $field = $(field);
@@ -28,6 +51,15 @@ Core.Agent.Admin.ProcessManagement.TransitionActionParameters = (function (Targe
         $('#ConfigValue[1]').val('');
     }
 
+    /**
+     * @private
+     * @name SetParameters
+     * @memberof Core.Agent.Admin.ProcessManagement.TransitionActionParameters
+     * @function
+     * @description
+     *      Retrieves the parameter list from the backend and 
+     *      shows the parameters in the dialog
+     */
     function SetParameters ( Module ) {
         let Data = {
             TransitionAction: Module,
@@ -81,6 +113,13 @@ Core.Agent.Admin.ProcessManagement.TransitionActionParameters = (function (Targe
         );
     }
 
+    /**
+     * @name Init
+     * @memberof Core.Agent.Admin.ProcessManagement.TransitionActionParameters
+     * @function
+     * @description
+     *      This function initializes the module functionality.
+     */
     TargetNS.Init = function() {
         $('#Module').on('change', function () {
             let Module = $('#Module option:selected').val();


### PR DESCRIPTION
One can do several actions during a transition in the process management.
For each action a TransitionAction module exists and those actions
need various parameters.

As it is hard to remember all the parameters, those parameters should be
shown in the dialog when an action module is selected. This commit implements
this behaviour.

Nevertheless, the reference that is shown under the parameter list could be
nicer. But I'm not a CSS ninja ;-)