### PR TITLE
Issue #282: Fixing the bug that selected dropdown elements in CustomerInterface are not properly colored

### DIFF
--- a/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
@@ -1028,22 +1028,22 @@ div.InputField_ToolbarContainer ul li a:hover {
 }
 
 .jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked {
-    background-color: var(--colNotifyOK);
     background-color: #c4cdfa;
+    background-color: var(--colNotifyOK);
 }
 
 .jstree-InputField .jstree-wholerow-ul .jstree-wholerow:hover,
 .jstree-InputField .jstree-wholerow-ul .jstree-wholerow-hovered,
 .jstree-InputField .jstree-focused > .jstree-wholerow {
-    background-color: var(--colBGLight);
     background-color: #f7f7f9;
+    background-color: var(--colBGLight);
 }
 
 .jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked:hover,
 .jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked.jstree-wholerow-hovered,
 .jstree-InputField .jstree-focused >.jstree-wholerow-clicked {
-    background-color: var(--colHoverLight);
     background-color: #6d83f2;
+    background-color: var(--colHoverLight);
 }
 
 /**

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
@@ -603,21 +603,6 @@ input[readonly=readonly] {
     height: 48px;
 }
 
-.jstree-node[aria-selected="true"] {
-    background-color: #c4cdfa;
-    background-color: var(--colNotifyOK);
-}
-
-.jstree-node > .jstree-wholerow-hovered {
-    background-color: #f7f7f9;
-    background-color: var(--colBGLight);
-}
-
-.jstree-node[aria-selected="true"] > .jstree-wholerow-hovered {
-    background-color: #6d83f2;
-    background-color: var(--colHoverLight);
-}
-
 .jstree-anchor {
     pointer-events: none;
     font-size: 16px;

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
@@ -1033,15 +1033,6 @@ div.InputField_ToolbarContainer ul li a:hover {
     content: "\e902";
 }
 
-.jstree-InputField-Tree .jstree-last {
-    background: transparent;
-}
-
-.jstree-InputField-Tree > .jstree-no-dots .jstree-node,
-.jstree-InputField-Tree > .jstree-no-dots .jstree-leaf > .jstree-ocl {
-    background: transparent;
-}
-
 /**
  * @subsection  jsTree theme - No Tree variant
  */

--- a/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.InputFields.css
@@ -1033,6 +1033,34 @@ div.InputField_ToolbarContainer ul li a:hover {
     content: "\e902";
 }
 
+.jstree-InputField-Tree .jstree-last {
+    background: transparent;
+}
+
+.jstree-InputField-Tree > .jstree-no-dots .jstree-node,
+.jstree-InputField-Tree > .jstree-no-dots .jstree-leaf > .jstree-ocl {
+    background: transparent;
+}
+
+.jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked {
+    background-color: var(--colNotifyOK);
+    background-color: #c4cdfa;
+}
+
+.jstree-InputField .jstree-wholerow-ul .jstree-wholerow:hover,
+.jstree-InputField .jstree-wholerow-ul .jstree-wholerow-hovered,
+.jstree-InputField .jstree-focused > .jstree-wholerow {
+    background-color: var(--colBGLight);
+    background-color: #f7f7f9;
+}
+
+.jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked:hover,
+.jstree-InputField .jstree-wholerow-ul .jstree-wholerow-clicked.jstree-wholerow-hovered,
+.jstree-InputField .jstree-focused >.jstree-wholerow-clicked {
+    background-color: var(--colHoverLight);
+    background-color: #6d83f2;
+}
+
 /**
  * @subsection  jsTree theme - No Tree variant
  */


### PR DESCRIPTION
The "background-color: transparent;" prevents the elements from being colored as it is the intended behavior. Though I'm not certainly sure, I could not find any negative impact of deleting this code.

Referencing #282 