### PR TITLE
For PUT/PATCH requests, the body is in param PUTDATA/PATCHDATA

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -237,7 +237,7 @@ sub ProviderProcessRequest {
     # The post data has already been read in. This should be safe
     # as $CGI::POST_MAX has been set as an emergency brake.
     # For Checking the length we can therefor use the actual length.
-    my $Content = $ParamObject->GetParam( Param => 'POSTDATA' );
+    my $Content = $ParamObject->GetParam( Param => uc($RequestMethod) . 'DATA' );
     my $Length  = length $Content;
 
     # No length provided, return the information we have.


### PR DESCRIPTION
If you import the "standard" GenericTicketConnectorREST.yml file and want to update a ticket, one has to use the PATCH HTTP method to send data. The data is in the body, but without this change nothing happens as the HTTP::REST transport class tries to get the query body from the parameter POSTDATA. But that parameter does not exist. Instead the parmeter name depends on the HTTP method used for the request (see https://metacpan.org/dist/CGI/source/lib/CGI.pm#L656). So the HTTP::REST transport class should use those parameter names.