### PR TITLE
Issue #1659: Strip the activity dialog id from the fieldname only whe…

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
@@ -605,8 +605,9 @@ Core.Agent.DynamicFieldDBSearch = (function(TargetNS) {
         }
 
         var FieldNameLong = Field;
-        if ( ActivityDialogID != '' ) {
-            Field = Field.substr(0, Field.indexOf('_' + ActivityDialogID));
+        var IndexOfActivityDialogID = Field.substr(0, Field.indexOf('_' + ActivityDialogID));
+        if ( ActivityDialogID != '' && IndexOfActivityDialogID > 0 ) {
+            Field = Field.substr(0, IndexOfActivityDialogID);
         }
 
         URL = Core.Config.Get('Baselink');


### PR DESCRIPTION
…n it is present.

Otherwise the field name becomes '' and that leads to error messages in the system log ('Need DynamicFieldName') and
to JavaScript errors as it cannot find the field in the dialog.