### PR TITLE
Issue #1661: Do not sort arrays numerically as the dynamic field can …

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -58,8 +58,8 @@ sub ValueIsDifferent {
 
     # Special cases where one value is a scalar and the other one is an array (see bug#13998).
     if ( ref \$Param{Value1} eq 'SCALAR' && ref $Param{Value2} eq 'ARRAY' ) {
-        my @TmpArray = sort { $a <=> $b } ( split ',', $Param{Value1} );
-        @{ $Param{Value2} } = sort { $a <=> $b } @{ $Param{Value2} };
+        my @TmpArray = sort split ',', $Param{Value1};
+        @{ $Param{Value2} } = sort @{ $Param{Value2} };
 
         return DataIsDifferent(
             Data1 => \@TmpArray,
@@ -67,8 +67,8 @@ sub ValueIsDifferent {
         );
     }
     if ( ref \$Param{Value2} eq 'SCALAR' && ref $Param{Value1} eq 'ARRAY' ) {
-        my @TmpArray = sort { $a <=> $b } ( split ',', $Param{Value2} );
-        @{ $Param{Value1} } = sort { $a <=> $b } @{ $Param{Value1} };
+        my @TmpArray = sort split ',', $Param{Value2};
+        @{ $Param{Value1} } = sort @{ $Param{Value1} };
 
         return DataIsDifferent(
             Data1 => $Param{Value1},


### PR DESCRIPTION
…store string values

and that would trigger a warning like 'Argument 'root@localhost' isn't numeric in sort at /opt/otobo/bin/psgi-bin/../../Kernel/System/DynamicField/Driver/BaseDatabase.pm line 71.'