### PR TITLE
Issue #1659 index correction

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
@@ -605,7 +605,7 @@ Core.Agent.DynamicFieldDBSearch = (function(TargetNS) {
         }
 
         var FieldNameLong = Field;
-        var IndexOfActivityDialogID = Field.substr(0, Field.indexOf('_' + ActivityDialogID));
+        var IndexOfActivityDialogID = Field.indexOf('_' + ActivityDialogID);
         if ( ActivityDialogID != '' && IndexOfActivityDialogID > 0 ) {
             Field = Field.substr(0, IndexOfActivityDialogID);
         }


### PR DESCRIPTION
IndexOfActivityDialog holds the substring, which leads the expression IndexOfActivityDialogID > 0 to return false, so the name is not shortened.

Closing #1659