### PR TITLE
Add support for CustomerIDRaw in GenericInterface TicketSearch operation

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
@@ -122,6 +122,13 @@ perform TicketSearch Operation. This will return a Ticket ID list.
         CustomerID => '123',
         CustomerID => ['123', 'ABC'],
 
+        # CustomerIDRaw (optional) as STRING or as ARRAYREF
+        # CustomerID without QueryCondition checking.
+        # The param CustomerID will be ignored when CustomerIDRaw is set.
+        # The raw values will be quoted and combined with 'OR' for the query.
+        CustomerIDRaw => '123 + 345',
+        CustomerIDRaw => ['123', 'ABC','123 && 456','ABC % efg'],
+
         # CustomerUserLogin (optional) as STRING as ARRAYREF
         CustomerUserLogin => 'uid123',
         CustomerUserLogin => ['uid123', 'uid777'],
@@ -409,7 +416,7 @@ sub _GetParams {
         CreatedTypes CreatedTypeIDs CreatedPriorities
         CreatedPriorityIDs CreatedStates CreatedStateIDs
         CreatedQueues CreatedQueueIDs StateType CustomerID
-        CustomerUserLogin )
+        CustomerIDRaw CustomerUserLogin )
         )
     {
 


### PR DESCRIPTION
Given a ticket with the customer id dummy+mojo@perl-services.de, you can't find
this ticket via the GenericInterface TicketSearch operation. This is the same
issue the standard TicketSearch functionality affected some time ago and that's
the reason the TicketSearch module added CustomerIDRaw at that time.

Unfortunately, the TicketSearch operation wasn't changed back then.

This is the ticket information from a sample ticket:

![image](https://user-images.githubusercontent.com/144096/162995381-9a99d4a1-6c4b-4c6d-879e-f5f2451d562e.png)

And this is a sample request with only CustomerID:

![image](https://user-images.githubusercontent.com/144096/162995511-dc3b4df5-223b-48f7-96a4-a29ab441a5f3.png)

And the same request with CustomerIDRaw instead of CustomerID:

![image](https://user-images.githubusercontent.com/144096/162995607-9e6421c7-c425-4054-81d2-862deb648d9a.png)
