### PR TITLE
Issue #1732: rename MaxRequestsPerChild to MaxConnectionsPerChild

### DIFF
--- a/scripts/apache2-httpd-cgi.include.conf
+++ b/scripts/apache2-httpd-cgi.include.conf
@@ -131,4 +131,4 @@ Alias       /otobo-web/ "/opt/otobo/var/httpd/htdocs/"
 
 # Limit the number of requests per child to avoid excessive memory usage.
 # 1000 is the same value as the default value used by Gazelle.
-MaxRequestsPerChild 1000
+MaxConnectionsPerChild 1000

--- a/scripts/apache2-httpd-fcgi.include.conf
+++ b/scripts/apache2-httpd-fcgi.include.conf
@@ -89,5 +89,6 @@ ProxyPassReverse "/otobo/" "fcgi://localhost:4000/otobo/"
     </Directory>
 </IfModule>
 
-# Limit the number of requests per child to avoid excessive memory usage
-MaxRequestsPerChild 4000
+# Limit the number of requests per child to avoid excessive memory usage.
+# 1000 is the same value as the default value used by Gazelle.
+MaxConnectionsPerChild 1000

--- a/scripts/apache2-httpd-plack-proxy.include.conf
+++ b/scripts/apache2-httpd-plack-proxy.include.conf
@@ -77,5 +77,6 @@ ProxyPassReverse "/otobo/" "http://localhost:5000/otobo/"
     </Directory>
 </IfModule>
 
-# Limit the number of requests per child to avoid excessive memory usage
-MaxRequestsPerChild 4000
+# Limit the number of requests per child to avoid excessive memory usage.
+# 1000 is the same value as the default value used by Gazelle.
+MaxConnectionsPerChild 1000

--- a/scripts/apache2-httpd-vhost-443.include.conf
+++ b/scripts/apache2-httpd-vhost-443.include.conf
@@ -81,4 +81,4 @@
 
 # Limit the number of requests per child to avoid excessive memory usage.
 # 1000 is the same value as the default value used by Gazelle.
-MaxRequestsPerChild 1000
+MaxConnectionsPerChild 1000

--- a/scripts/apache2-httpd.include.conf
+++ b/scripts/apache2-httpd.include.conf
@@ -47,4 +47,4 @@
 
 # Limit the number of requests per child to avoid excessive memory usage.
 # 1000 is the same value as the default value used by Gazelle.
-MaxRequestsPerChild 1000
+MaxConnectionsPerChild 1000


### PR DESCRIPTION
Consistently use the value 1000