### PR TITLE
Set lock only if owner was updated in AgentTicketFreeText

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1053,17 +1053,20 @@ sub Run {
                 String => $GetParam{Body} || '',
             );
             if ( $GetParam{NewOwnerID} ) {
-                $TicketObject->TicketLockSet(
-                    TicketID => $Self->{TicketID},
-                    Lock     => 'lock',
-                    UserID   => $Self->{UserID},
-                );
                 my $Success = $TicketObject->TicketOwnerSet(
                     TicketID  => $Self->{TicketID},
                     UserID    => $Self->{UserID},
                     NewUserID => $GetParam{NewOwnerID},
                     Comment   => $BodyText,
                 );
+                # Set lock only if owner was updated
+                if ($Success == 1) {
+                    $TicketObject->TicketLockSet(
+                        TicketID => $Self->{TicketID},
+                        Lock     => 'lock',
+                        UserID   => $Self->{UserID},
+                    );
+                }
                 $UnlockOnAway = 0;
 
                 # remember to not notify owner twice


### PR DESCRIPTION
If the owner field is present in AgentTicketFreeText the ticket gets locked on submit. Even if the owner did not change and _Ticket::Frontend::AgentTicketFreeText###RequiredLock_ is not set. 

I think a lock should either never be set as long as  _Ticket::Frontend::AgentTicketFreeText###RequiredLock_ is not set. Or it should only be set if the owner changed.