### PR TITLE
Issue #1799: skip PGP and SMIME tests when S3 is active

### DIFF
--- a/scripts/test/Selenium/Agent/Admin/AdminPGP.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPGP.t
@@ -14,19 +14,25 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 # --
 
+use v5.24;
 use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
-
-use vars (qw($Self));
-
+# core modules
 use File::Path qw(mkpath rmtree);
 
+# CPAN modules
+use Test2::V0;
+
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+skip_all('Key management not implemented for the S3 case. See https://github.com/RotherOSS/otobo/issues/1799') if $ENV{OTOBO_SYNC_WITH_S3};
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 $Selenium->RunTest(
@@ -218,4 +224,4 @@ $Selenium->RunTest(
 
 );
 
-$Self->DoneTesting();
+done_testing();

--- a/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSMIME.t
@@ -29,6 +29,8 @@ use Test2::V0;
 use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
 
+skip_all('Key management not implemented for the S3 case. See https://github.com/RotherOSS/otobo/issues/1799') if $ENV{OTOBO_SYNC_WITH_S3};
+
 our $Self;
 
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );

--- a/scripts/test/Selenium/Agent/Admin/AgentTicketEmailSMIME.t
+++ b/scripts/test/Selenium/Agent/Admin/AgentTicketEmailSMIME.t
@@ -14,19 +14,25 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 # --
 
+use v5.24;
 use strict;
 use warnings;
 use utf8;
 
-# Set up the test driver $Self when we are running as a standalone script.
-use Kernel::System::UnitTest::RegisterDriver;
-
-use vars (qw($Self));
-
+# core modules
 use File::Path qw(mkpath rmtree);
 
+# CPAN modules
+use Test2::V0;
+
 # OTOBO modules
+use Kernel::System::UnitTest::RegisterDriver;    # Set up $Kernel::OM and the test driver $Self
 use Kernel::System::UnitTest::Selenium;
+
+skip_all('Key management not implemented for the S3 case. See https://github.com/RotherOSS/otobo/issues/1799') if $ENV{OTOBO_SYNC_WITH_S3};
+
+our $Self;
+
 my $Selenium = Kernel::System::UnitTest::Selenium->new( LogExecuteCommandActive => 1 );
 
 $Selenium->RunTest(
@@ -300,4 +306,4 @@ $Selenium->RunTest(
     }
 );
 
-$Self->DoneTesting();
+done_testing();


### PR DESCRIPTION
because sharing of the keys is not implemented yet