### PR TITLE
Fix in sub ArticleActions re ACL restrictions (by maxence)

### DIFF
--- a/Kernel/Output/HTML/Article/Base.pm
+++ b/Kernel/Output/HTML/Article/Base.pm
@@ -188,7 +188,7 @@ sub ArticleActions {
     my $ACL = $TicketObject->TicketAcl(
         Data          => \%PossibleActions,
         Action        => 'AgentTicketZoom',
-        TicketID      => $Param{Ticket}->{TicketID},
+        TicketID      => $Param{TicketID},
         ReturnType    => 'Action',
         ReturnSubType => '-',
         UserID        => $Param{UserID},


### PR DESCRIPTION
Trigger was that we wanted to hide the print button in articles via ACL. This worked well in an open Ticket. However, in the Ticket Overview, e.g. by Queue, the print button was still visible in the large view.

I found the reason for this in module Article/Base.pm. Here in "sub ArticleActions" it is checked whether an ACL is active. The Ticket ID is passed here as follows:
```TicketID => $Param{Ticket}->{TicketID},```

The problem is that this parameter is passed when displaying an open ticket, but not when displaying a Ticket Overview. Therefore the print button for a ticket (or its article) is not hidden (see screenshot).
![Screenshot-1](https://user-images.githubusercontent.com/111051858/184113943-090f855c-7ca6-4a8d-ad00-30c23c017334.png)

In the call of the function "sub ArticleActions", however, it is checked whether the TicketID is passed as a parameter:
```for my $Needed (qw(TicketID ArticleID Type UserID)) {```

This means that the TicketID is present in any case, because otherwise the function is cancelled.

I therefore suggest changing the line stated above as follows:
```TicketID => $Param{TicketID},```

With this setting, the ACL will also be taken into account in the Ticket Overview, i.e. the print button will be hidden (see screenshot).
![Screenshot-2](https://user-images.githubusercontent.com/111051858/184114157-13966dfd-908b-400f-ba99-dcd7a0568cc5.png)

