### PR TITLE
Fix typo on customer logo

### DIFF
--- a/var/httpd/htdocs/skins/Customer/default/css/Core.NavigationBar.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/Core.NavigationBar.css
@@ -159,7 +159,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 #oooNavigation #oooSignet {
-    width: 32x;
+    width: 32px;
 }
 
 /* User */


### PR DESCRIPTION
The width had a typo on the value of _oooNavigation_ and _oooSignet_ classes, this will fix it.
This bug can also be found in version 10.0.x