### PR TITLE
Fixed uninitialized value warning in AdminSystemMaintenance

### DIFF
--- a/Kernel/Modules/AdminSystemMaintenance.pm
+++ b/Kernel/Modules/AdminSystemMaintenance.pm
@@ -246,7 +246,7 @@ sub Run {
             );
         }
 
-        if ( $ParamObject->GetParam( Param => 'Notification' ) eq 'Add' ) {
+        if ( ($ParamObject->GetParam( Param => 'Notification' ) || '') eq 'Add' ) {
 
             # add notification
             push @NotifyData, {
@@ -255,7 +255,7 @@ sub Run {
             };
         }
 
-        if ( $ParamObject->GetParam( Param => 'Notification' ) eq 'Update' ) {
+        if ( ($ParamObject->GetParam( Param => 'Notification' ) || '') eq 'Update' ) {
 
             # add notification
             push @NotifyData, {

--- a/Kernel/Modules/AdminSystemMaintenance.pm
+++ b/Kernel/Modules/AdminSystemMaintenance.pm
@@ -246,7 +246,7 @@ sub Run {
             );
         }
 
-        if ( ($ParamObject->GetParam( Param => 'Notification' ) || '') eq 'Add' ) {
+        if ( ($ParamObject->GetParam( Param => 'Notification' ) // '') eq 'Add' ) {
 
             # add notification
             push @NotifyData, {
@@ -255,7 +255,7 @@ sub Run {
             };
         }
 
-        if ( ($ParamObject->GetParam( Param => 'Notification' ) || '') eq 'Update' ) {
+        if ( ($ParamObject->GetParam( Param => 'Notification' ) // '') eq 'Update' ) {
 
             # add notification
             push @NotifyData, {


### PR DESCRIPTION
Clicking on a link to edit a AdminSystemMaintenance-Entry logs a warning because there is no `Notification` parameter given yet `Action=AdminSystemMaintenance;Subaction=SystemMaintenanceEdit;SystemMaintenanceID=1`
```
[Thu Sep 29 17:29:39 2022] index.pl: Use of uninitialized value in string eq at /opt/frameworks/Znuny-Dev/bin/cgi-bin/../../Kernel/Modules/AdminSystemMaintenance.pm line 242.
[Thu Sep 29 17:29:39 2022] index.pl: Use of uninitialized value in string eq at /opt/frameworks/Znuny-Dev/bin/cgi-bin/../../Kernel/Modules/AdminSystemMaintenance.pm line 251.
```
