### PR TITLE
Fixed hidden filters for Medium and Preview

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/Medium.pm
+++ b/Kernel/Output/HTML/TicketOverview/Medium.pm
@@ -36,6 +36,7 @@ our @ObjectDependencies = (
     'Kernel::System::Group',
     'Kernel::System::Log',
     'Kernel::Output::HTML::Layout',
+    'Kernel::System::JSON',
     'Kernel::System::User',
     'Kernel::System::Ticket',
     'Kernel::System::Ticket::Article',

--- a/Kernel/Output/HTML/TicketOverview/Medium.pm
+++ b/Kernel/Output/HTML/TicketOverview/Medium.pm
@@ -53,6 +53,22 @@ sub new {
     # get UserID param
     $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
 
+    my %Preferences = $Kernel::OM->Get('Kernel::System::User')->GetPreferences(
+        UserID => $Self->{UserID},
+    );
+
+    # get JSON object
+    my $JSONObject = $Kernel::OM->Get('Kernel::System::JSON');
+
+    # set stored filters if present
+    my $StoredFiltersKey = 'UserStoredFilterColumns-' . $Self->{Action};
+    if ( $Preferences{$StoredFiltersKey} ) {
+        my $StoredFilters = $JSONObject->Decode(
+            Data => $Preferences{$StoredFiltersKey},
+        );
+        $Self->{StoredFilters} = $StoredFilters;
+    }
+
     return $Self;
 }
 

--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -55,6 +55,22 @@ sub new {
     # get UserID param
     $Self->{UserID} = $Param{UserID} || die "Got no UserID!";
 
+    my %Preferences = $Kernel::OM->Get('Kernel::System::User')->GetPreferences(
+        UserID => $Self->{UserID},
+    );
+
+    # get JSON object
+    my $JSONObject = $Kernel::OM->Get('Kernel::System::JSON');
+
+    # set stored filters if present
+    my $StoredFiltersKey = 'UserStoredFilterColumns-' . $Self->{Action};
+    if ( $Preferences{$StoredFiltersKey} ) {
+        my $StoredFilters = $JSONObject->Decode(
+            Data => $Preferences{$StoredFiltersKey},
+        );
+        $Self->{StoredFilters} = $StoredFilters;
+    }
+
     return $Self;
 }
 

--- a/Kernel/Output/HTML/TicketOverview/Preview.pm
+++ b/Kernel/Output/HTML/TicketOverview/Preview.pm
@@ -38,6 +38,7 @@ our @ObjectDependencies = (
     'Kernel::System::Group',
     'Kernel::System::Log',
     'Kernel::Output::HTML::Layout',
+    'Kernel::System::JSON',
     'Kernel::System::User',
     'Kernel::System::Ticket',
     'Kernel::System::Ticket::Article',


### PR DESCRIPTION
It is possible to set filters in the Small view. Those filters are still used for Medium and Preview, but here is the delete button missing, so you can't remove the filters or even see, that filters are set.
![image](https://user-images.githubusercontent.com/80031303/193153646-4dc2c159-8495-4e69-81e8-09629a9688b2.png)
This PR fixes this by adding the stored filters to $Self which results in usable delete buttons.