### PR TITLE
Fixed double encoding for dynamic field values in the linked-tickets-table

### DIFF
--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -545,6 +545,7 @@ sub TableCreateComplex {
                     my $ValueStrg = $Kernel::OM->Get('Kernel::System::DynamicField::Backend')->DisplayValueRender(
                         DynamicFieldConfig => $DynamicFieldConfig,
                         Value              => $Value,
+                        HTMLOutput         => 0,
                         ValueMaxChars      => 20,
                         LayoutObject       => $Self->{LayoutObject},
                     );


### PR DESCRIPTION
The values of dynamic fields in the complex link table in the AgentTicketZoom are overly encoded. `<b>Big</b>` Is the value
![image](https://user-images.githubusercontent.com/80031303/193133169-33aacea5-9c46-4c33-93d7-a857b885cc8d.png)

This change would fix it to

![image](https://user-images.githubusercontent.com/80031303/193132836-e7b3c2c3-d5b3-4dd5-997b-be9ec0bf5e84.png)