### PR TITLE
Issue #1312: Fix label for the link to the admin manual

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminNavigationBar.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminNavigationBar.tt
@@ -58,7 +58,7 @@
             <div class="Content">
                 <ul class="ActionList">
                     <li>
-                        <a href="https://doc.otobo.org/manual/admin/10.0/en/content/index.html" target="_blank" class="CallForAction Fullsize Center"><span><i class="fa fa-book"></i>[% Translate("View the admin manual on Github") | html %]</span></a>
+                        <a href="https://doc.otobo.org/manual/admin/10.0/en/content/index.html" target="_blank" class="CallForAction Fullsize Center"><span><i class="fa fa-book"></i>[% Translate("View the admin manual") | html %]</span></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
While the admin manual is on GitHub too, the link points to doc.otobo.org.