### PR TITLE
Add sorting of screens in Dynamic Field Screen Manager

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldScreen.pm
+++ b/Kernel/Modules/AdminDynamicFieldScreen.pm
@@ -287,7 +287,7 @@ sub _ShowOverview {
     # show output
     $LayoutObject->Block( Name => 'Overview' );
 
-    for my $DynamicFieldScreen ( sort keys %DynamicFieldScreens ) {
+    for my $DynamicFieldScreen ( sort { $DynamicFieldScreens{$a} cmp $DynamicFieldScreens{$b} } keys %DynamicFieldScreens ) {
 
         # output row for DynamicFieldScreen
         $LayoutObject->Block(
@@ -299,7 +299,7 @@ sub _ShowOverview {
         );
     }
 
-    for my $DefaultColumnsScreen ( sort keys %DefaultColumnsScreens ) {
+    for my $DefaultColumnsScreen ( sort { $DefaultColumnsScreens{$a} cmp $DefaultColumnsScreens{$b} } keys %DefaultColumnsScreens ) {
 
         # output row for DefaultColumns
         $LayoutObject->Block(

--- a/Kernel/Modules/AdminDynamicFieldScreen.pm
+++ b/Kernel/Modules/AdminDynamicFieldScreen.pm
@@ -401,7 +401,7 @@ sub _ShowEdit {
     );
 
     # shows sidebar selection
-    for my $Element ( sort keys %OtherElements ) {
+    for my $Element ( sort { $OtherElements{$a} cmp $OtherElements{$b} } keys %OtherElements ) {
 
         # output row
         $LayoutObject->Block(


### PR DESCRIPTION
In „Management of Dynamic Fields <-> Screens“ (AdminDynamicFieldScreen) dynamic field screens and default column screens get sorted by the key of the setting and not the value of the setting.

This PR adds proper sorting.
Old:
<img width="400" alt="old" src="https://user-images.githubusercontent.com/5484272/209217613-4a8e1889-db58-418a-aaf7-884fa8d59343.png">

New:
<img width="400" alt="new" src="https://user-images.githubusercontent.com/5484272/209217758-3a9726de-ae7e-47e8-87b1-a8f5355a5c5c.png">

