### PR TITLE
Issue #2116: avoid violations of Variables::RequireInitializationForL…

### DIFF
--- a/Kernel/Language/es_MX.pm
+++ b/Kernel/Language/es_MX.pm
@@ -6393,7 +6393,7 @@ Thanks for your help!
 ' => '
 Estimado cliente,
 
-Lamentablemente no hemos podido detectar un número de ticket válido 
+Lamentablemente no hemos podido detectar un número de ticket válido
 en su asunto, por lo que este correo no puede ser procesado.
 
 Por favor, cree un nuevo ticket a través del panel de cliente.

--- a/Kernel/System/Console/Command/Admin/Package/UpgradeAll.pm
+++ b/Kernel/System/Console/Command/Admin/Package/UpgradeAll.pm
@@ -136,7 +136,7 @@ sub Run {
     eval {
         # Localize the standard error, everything will be restored after the eval block.
         # Package installation or upgrades always produce messages in STDERR for files and directories.
-        local *STDERR;
+        local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
         # Redirect the standard error to a variable.
         open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/Kernel/System/Console/Command/Dev/Tools/Database/XML2SQL.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/Database/XML2SQL.pm
@@ -116,7 +116,7 @@ sub Run {
     }
     else {
         # read xml data from STDIN
-        $SourceXML = do { local $/; <> };
+        $SourceXML = do { local $/ = undef; <> };
     }
 
     for my $DatabaseType (@DatabaseType) {

--- a/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
+++ b/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
@@ -172,7 +172,7 @@ sub Run {
             eval {
 
                 # Localize the standard error, everything will be restored after the eval block.
-                local *STDERR;
+                local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
                 # Redirect the standard error to a variable.
                 open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -262,7 +262,7 @@ sub Connect {
         # have the callbacks with the attributes.
         # But for now, the Callbacks are not part of the cache key in order to avoid serialised code.
         my $CacheKey = do {
-            local $^W;
+            local $^W = undef;
 
             join
                 "!\001",

--- a/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/AsynchronousExecutor.pm
+++ b/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/AsynchronousExecutor.pm
@@ -130,7 +130,7 @@ sub Run {
         local $SIG{CHLD} = 'DEFAULT';
 
         # Localize the standard error, everything will be restored after the eval block.
-        local *STDERR;
+        local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
         # Redirect the standard error to a variable.
         open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/Cron.pm
+++ b/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/Cron.pm
@@ -139,7 +139,7 @@ sub Run {
         local $SIG{CHLD} = 'DEFAULT';
 
         # Localize the standard error, everything will be restored after the eval block.
-        local *STDERR;
+        local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
         # Redirect the standard error to a variable.
         open STDERR, ">>", \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)
@@ -148,8 +148,7 @@ sub Run {
         #   will be clean.
         # Prevent used once warning, setting the variable as local and then assign the value
         #   in the next statement.
-        local $Kernel::System::Console::BaseCommand::SuppressANSI;
-        $Kernel::System::Console::BaseCommand::SuppressANSI = 1;
+        local $Kernel::System::Console::BaseCommand::SuppressANSI = 1;
 
         # Run function on the module with the specified parameters in Data->{Params}
         $Result = $ModuleObject->$Function(

--- a/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/GenericAgent.pm
+++ b/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker/GenericAgent.pm
@@ -129,7 +129,7 @@ sub Run {
         local $SIG{CHLD} = 'DEFAULT';
 
         # Localize the standard error, everything will be restored after the eval block.
-        local *STDERR;
+        local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
         # Redirect the standard error to a variable.
         open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/Kernel/System/Daemon/DaemonModules/SystemConfigurationSyncManager.pm
+++ b/Kernel/System/Daemon/DaemonModules/SystemConfigurationSyncManager.pm
@@ -140,7 +140,7 @@ sub Run {
         local $SIG{CHLD} = 'DEFAULT';
 
         # Localize the standard error, everything will be restored after the eval block.
-        local *STDERR;
+        local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
         # Redirect the standard error to a variable.
         open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -483,7 +483,7 @@ sub FileRead {
     }
 
     # read file as string
-    my $String = do { local $/; <$FH> };
+    my $String = do { local $/ = undef; <$FH> };
     close $FH;
 
     return \$String;

--- a/Kernel/System/MigrateFromOTRS/OTOBOPackageSpecifics.pm
+++ b/Kernel/System/MigrateFromOTRS/OTOBOPackageSpecifics.pm
@@ -205,7 +205,7 @@ sub _ITSM_ChangeDefinition {
     my ( $Result, $ExitCode );
 
     {
-        local *STDOUT;
+        local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
         $ExitCode = $CommandObject->Execute();
     }

--- a/Kernel/System/SupportBundleGenerator.pm
+++ b/Kernel/System/SupportBundleGenerator.pm
@@ -241,7 +241,7 @@ sub Generate {
     # add files to the tar archive
     open( my $Tar, '<', $Archive );    ## no critic qw(OTOBO::ProhibitOpen)
     binmode $Tar;
-    my $TmpTar = do { local $/; <$Tar> };
+    my $TmpTar = do { local $/ = undef; <$Tar> };
     close $Tar;
 
     # remove all files
@@ -395,7 +395,7 @@ sub GenerateCustomFilesArchive {
     }
 
     binmode $TARFH;
-    my $TmpTar = do { local $/; <$TARFH> };
+    my $TmpTar = do { local $/ = undef; <$TARFH> };
     close $TARFH;
 
     if ( $Kernel::OM->Get('Kernel::System::Main')->Require('Compress::Zlib') ) {

--- a/Kernel/System/SupportDataCollector/Plugin/OS/PerlModulesAudit.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OS/PerlModulesAudit.pm
@@ -40,7 +40,7 @@ sub Run {
     my ( $CommandOutput, $ExitCode );
 
     {
-        local *STDOUT;
+        local *STDOUT;                             ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:utf8', \$CommandOutput;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
         $ExitCode = $CommandObject->Execute();
     }

--- a/bin/otobo.Daemon.pl
+++ b/bin/otobo.Daemon.pl
@@ -450,7 +450,7 @@ sub Status {
         if ( !flock( $FH, LOCK_EX | LOCK_NB ) ) {
 
             # if no exclusive lock, daemon might be running, send signal to the PID
-            my $RegisteredPID = do { local $/; <$FH> };
+            my $RegisteredPID = do { local $/ = undef; <$FH> };
             close $FH;
 
             if ($RegisteredPID) {
@@ -515,7 +515,7 @@ sub _PIDLock {
             return;
         }
 
-        my $RegisteredPID = do { local $/; <$FH> };
+        my $RegisteredPID = do { local $/ = undef; <$FH> };
         close $FH;
 
         if ($RegisteredPID) {
@@ -551,7 +551,7 @@ sub _PIDUnlock {
 
     # wait if PID is exclusively locked (and do a shared lock for reading)
     flock $FH, LOCK_SH;
-    my $RegisteredPID = do { local $/; <$FH> };
+    my $RegisteredPID = do { local $/ = undef; <$FH> };
     close $FH;
 
     unlink $PIDFile;

--- a/scripts/test/Console/Command/Admin/Config/FixInvalid.t
+++ b/scripts/test/Console/Command/Admin/Config/FixInvalid.t
@@ -40,7 +40,7 @@ my $SysConfigDBObject = $Kernel::OM->Get('Kernel::System::SysConfig::DB');
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }
@@ -92,7 +92,7 @@ else {
 ok( $Success, 'Setting updated' );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('--non-interactive');
 }

--- a/scripts/test/Console/Command/Admin/Config/FixInvalidSkipMissing.t
+++ b/scripts/test/Console/Command/Admin/Config/FixInvalidSkipMissing.t
@@ -42,8 +42,8 @@ my $RunCommand = sub {
     $ResultOut = '';
 
     {
-        local *STDERR;
-        local *STDOUT;
+        local *STDERR;                         ## no critic qw(Variables::RequireInitializationForLocalVars)
+        local *STDOUT;                         ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDERR, '>:utf8', \$ResultErr;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
         open STDOUT, '>:utf8', \$ResultOut;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
         $ExitCode = $CommandObject->Execute( '--non-interactive', @Args, );

--- a/scripts/test/Console/Command/Admin/Config/ListInvalid.t
+++ b/scripts/test/Console/Command/Admin/Config/ListInvalid.t
@@ -37,7 +37,7 @@ my $SysConfigDBObject = $Kernel::OM->Get('Kernel::System::SysConfig::DB');
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }
@@ -97,7 +97,7 @@ $Self->True(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }

--- a/scripts/test/Console/Command/Admin/Config/ListInvalidFixInvalid.t
+++ b/scripts/test/Console/Command/Admin/Config/ListInvalidFixInvalid.t
@@ -38,7 +38,7 @@ my $SysConfigDBObject = $Kernel::OM->Get('Kernel::System::SysConfig::DB');
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListCommandObject->Execute();
 }
@@ -55,7 +55,7 @@ $Self->True(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $FixCommandObject->Execute();
 }
@@ -139,7 +139,7 @@ for my $SettingName ( sort keys %Settings ) {
 }
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListCommandObject->Execute();
 }
@@ -161,7 +161,7 @@ $Self->True(
 # Have ListInvalid write yml file with invalid config.
 my $YAMLFile = $Kernel::OM->Get('Kernel::Config')->Get('Home') . '/var/tmp/ListInvalidFixInvalid.yml';
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListCommandObject->Execute( '--export-to-path', $YAMLFile );
 }
@@ -218,7 +218,7 @@ $Self->True(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $FixCommandObject->Execute( '--values-from-path', $YAMLFile, '--non-interactive' );
 }
@@ -238,7 +238,7 @@ $Self->True(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListCommandObject->Execute();
 }

--- a/scripts/test/Console/Command/Admin/Config/UnlockAll.t
+++ b/scripts/test/Console/Command/Admin/Config/UnlockAll.t
@@ -27,7 +27,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Admin::C
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Admin/Package/UpgradeAll.t
+++ b/scripts/test/Console/Command/Admin/Package/UpgradeAll.t
@@ -62,7 +62,7 @@ else {
 
     my ( $Result, $ExitCode );
     {
-        local *STDOUT;
+        local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
         $ExitCode = $CommandObject->Execute();
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Admin/Queue/List.t
+++ b/scripts/test/Console/Command/Admin/Queue/List.t
@@ -49,7 +49,7 @@ my $QueueID = $Kernel::OM->Get('Kernel::System::Queue')->QueueAdd(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }
@@ -68,7 +68,7 @@ $Self->True(
 $Result = '';
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('--all');
 }
@@ -87,7 +87,7 @@ $Self->True(
 $Result = '';
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute( '--all', '--verbose' );
 }

--- a/scripts/test/Console/Command/Admin/WebService/List.t
+++ b/scripts/test/Console/Command/Admin/WebService/List.t
@@ -59,7 +59,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Admin::W
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }

--- a/scripts/test/Console/Command/Dev/Code/CPANAudit.t
+++ b/scripts/test/Console/Command/Dev/Code/CPANAudit.t
@@ -29,7 +29,7 @@ my $ExitCode = $CommandObject->Execute();
 
 my $Output;
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Output;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Output );

--- a/scripts/test/Console/Command/Dev/Package/RepositoryIndex.t
+++ b/scripts/test/Console/Command/Dev/Package/RepositoryIndex.t
@@ -37,7 +37,7 @@ my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 my $Result;
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute("$Home/Kernel/Config/Files");
 }

--- a/scripts/test/Console/Command/Dev/Tools/Config2Docbook.t
+++ b/scripts/test/Console/Command/Dev/Tools/Config2Docbook.t
@@ -36,7 +36,7 @@ $Self->Is(
 
 my $Result;
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute( '--language', 'en' );
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Dev/Tools/Migrate/OTRSToOTOBO.t
+++ b/scripts/test/Console/Command/Dev/Tools/Migrate/OTRSToOTOBO.t
@@ -39,7 +39,7 @@ subtest
     sub {
         my ( $ExitCode, $Stderr );
         {
-            local *STDERR;
+            local *STDERR;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
             open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--source" => "$Home/Kernel/Config/Files/NotExisting/Source",
@@ -59,7 +59,7 @@ subtest
     sub {
         my ( $ExitCode, $Stderr );
         {
-            local *STDERR;
+            local *STDERR;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
             open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--target" => "$Home/Kernel/Config/Files/NotExisting/Target",
@@ -80,7 +80,7 @@ subtest
     sub {
         my ( $ExitCode, $Stderr );
         {
-            local *STDERR;
+            local *STDERR;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
             open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 "--target" => "$Home/Kernel/Config/Files/NotExisting/Target",
@@ -113,7 +113,7 @@ subtest
 
         my ( $ExitCode, $Stderr );
         {
-            local *STDERR;
+            local *STDERR;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
             open STDERR, '>:encoding(UTF-8)', \$Stderr;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute(
                 '--cleanxmlconfig',

--- a/scripts/test/Console/Command/Dev/Tools/Shell.t
+++ b/scripts/test/Console/Command/Dev/Tools/Shell.t
@@ -82,7 +82,7 @@ else {
         my $Result;
         my $ExitCode;
         {
-            local *STDOUT;
+            local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
             open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
             $ExitCode = $CommandObject->Execute( '--eval', $Test->{Code} );
             $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Help.t
+++ b/scripts/test/Console/Command/Help.t
@@ -28,7 +28,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Help');
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }
@@ -41,7 +41,7 @@ $Self->Is(
 # Check command help
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('Help');
 }
@@ -60,7 +60,7 @@ $Self->True(
 # Check command search
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('Lis');
 }
@@ -84,7 +84,7 @@ $Self->True(
 # Check command search (empty)
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('NonExistingSearchTerm');
 }

--- a/scripts/test/Console/Command/Internal/BashCompletion.t
+++ b/scripts/test/Console/Command/Internal/BashCompletion.t
@@ -57,7 +57,7 @@ for my $Test (@Tests) {
 
     {
         local $ENV{COMP_LINE} = $Test->{COMP_LINE};
-        local *STDOUT;
+        local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
         $ExitCode = $CommandObject->Execute( @{ $Test->{Arguments} } );
     }

--- a/scripts/test/Console/Command/Maint/Config/Dump.t
+++ b/scripts/test/Console/Command/Maint/Config/Dump.t
@@ -28,7 +28,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::C
 my ( $Result, $ExitCode );
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('Home');
 }

--- a/scripts/test/Console/Command/Maint/Config/Sync.t
+++ b/scripts/test/Console/Command/Maint/Config/Sync.t
@@ -27,7 +27,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::C
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/GenericInterface/DebugLog/Cleanup.t
+++ b/scripts/test/Console/Command/Maint/GenericInterface/DebugLog/Cleanup.t
@@ -58,7 +58,7 @@ my @Tests = (
 for my $Test (@Tests) {
 
     {
-        local *STDOUT;
+        local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
         $ExitCode = $CommandObject->Execute( @{ $Test->{Config} } );
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/Log/Clear.t
+++ b/scripts/test/Console/Command/Maint/Log/Clear.t
@@ -39,7 +39,7 @@ $Self->True(
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/Log/CommunicationLog.t
+++ b/scripts/test/Console/Command/Maint/Log/CommunicationLog.t
@@ -100,13 +100,13 @@ my $RunTest = sub {
     my ( $ExitCode, $Result );
 
     if ( $Test->{Output} && $Test->{Output} eq 'STDOUT' ) {
-        local *STDOUT;
+        local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
         $ExitCode = $CommandObject->Execute( @{ $Test->{Params} } );
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );
     }
     else {
-        local *STDERR;
+        local *STDERR;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDERR, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
         $ExitCode = $CommandObject->Execute( @{ $Test->{Params} } );
         $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/Log/Print.t
+++ b/scripts/test/Console/Command/Maint/Log/Print.t
@@ -30,7 +30,7 @@ $LogObject->CleanUp();
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );
@@ -54,7 +54,7 @@ $Self->Is(
 );
 
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/PostMaster/Read.t
+++ b/scripts/test/Console/Command/Maint/PostMaster/Read.t
@@ -36,7 +36,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::P
 my ( $ExitCode, $Result );
 
 {
-    local *STDIN;
+    local *STDIN;                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDIN, '<:utf8', \'';    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }
@@ -49,9 +49,9 @@ $Self->Is(
 
 {
     my $Email = "From: me\@home.com\nTo: you\@home.com\nSubject: Test\nUnit tests rock.\n";
-    local *STDIN;
-    open STDIN, '<:utf8', \$Email;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
-    local *STDOUT;
+    local *STDIN;                       ## no critic qw(Variables::RequireInitializationForLocalVars)
+    open STDIN, '<:utf8', \$Email;      ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute();
 }

--- a/scripts/test/Console/Command/Maint/SMIME/CustomerCertificate/Fetch.t
+++ b/scripts/test/Console/Command/Maint/SMIME/CustomerCertificate/Fetch.t
@@ -136,7 +136,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::S
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute('--add-all');
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/SMIME/CustomerCertificate/Renew.t
+++ b/scripts/test/Console/Command/Maint/SMIME/CustomerCertificate/Renew.t
@@ -136,7 +136,7 @@ my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::S
 
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                                 ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:encoding(UTF-8)', \$Result;    ## no critic qw(OTOBO::ProhibitOpen)
     $ExitCode = $CommandObject->Execute();
     $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Result );

--- a/scripts/test/Console/Command/Maint/Sessions/Commands.t
+++ b/scripts/test/Console/Command/Maint/Sessions/Commands.t
@@ -52,7 +52,7 @@ my ( $Result, $ExitCode );
 # get ListAll command object
 my $ListAllCommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Session::ListAll');
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListAllCommandObject->Execute();
 }
@@ -88,7 +88,7 @@ $Self->Is(
 undef $Result;
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListAllCommandObject->Execute();
 }
@@ -133,7 +133,7 @@ undef $Result;
 # get ListExpired command object
 my $ListExpiredCommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Session::ListExpired');
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListExpiredCommandObject->Execute();
 }
@@ -157,7 +157,7 @@ $Kernel::OM->Get('Kernel::Config')->Set(
 undef $Result;
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $ListExpiredCommandObject->Execute();
 }

--- a/scripts/test/Console/Command/Maint/Ticket/Dump.t
+++ b/scripts/test/Console/Command/Maint/Ticket/Dump.t
@@ -101,7 +101,7 @@ $Self->True(
 my $Result;
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute( $TicketID, '--no-ansi' );
 }

--- a/scripts/test/Console/Command/Search.t
+++ b/scripts/test/Console/Command/Search.t
@@ -37,7 +37,7 @@ $Self->Is(
 my $Result;
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('Lis');
 }
@@ -61,7 +61,7 @@ $Self->True(
 # Check command search (empty)
 
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     $ExitCode = $CommandObject->Execute('NonExistingSearchTerm');
 }

--- a/scripts/test/Daemon/DaemonModules/SchedulerTaskWorker/SystemCallTask.t
+++ b/scripts/test/Daemon/DaemonModules/SchedulerTaskWorker/SystemCallTask.t
@@ -57,7 +57,7 @@ my $RunTasks = sub {
 
     # Localize the standard error, to prevent redefining warnings.
     #   WARNING: This also hides any task run errors.
-    local *STDERR;
+    local *STDERR;    ## no critic qw(Variables::RequireInitializationForLocalVars)
 
     # Redirect the standard error to a variable.
     open STDERR, '>>', \$ErrorMessage;    ## no critic qw(OTOBO::ProhibitOpen)

--- a/scripts/test/Stats.t
+++ b/scripts/test/Stats.t
@@ -487,7 +487,7 @@ my $Stat4 = $StatsObject->StatsGet( StatID => $StatID );
 my $Home  = $ConfigObject->Get('Home');
 my ( $Result, $ExitCode );
 {
-    local *STDOUT;
+    local *STDOUT;                      ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDOUT, '>:utf8', \$Result;    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireEncodingWithUTF8Layer)
     my $CommandObject = $Kernel::OM->Get('Kernel::System::Console::Command::Maint::Stats::Generate');
     $ExitCode = $CommandObject->Execute( '--number', $Stat4->{StatNumber}, '--target-directory', "$Home/var/tmp/" );

--- a/scripts/test/Ticket.t
+++ b/scripts/test/Ticket.t
@@ -369,7 +369,7 @@ $Self->True(
 my $ErrorOutput = '';
 
 {
-    local *STDERR;
+    local *STDERR;                       ## no critic qw(Variables::RequireInitializationForLocalVars)
     open STDERR, '>>', \$ErrorOutput;    ## no critic qw(OTOBO::ProhibitOpen)
 
     %TicketIDs = $TicketObject->TicketSearch(

--- a/scripts/test/UnitTest/Blacklist.t
+++ b/scripts/test/UnitTest/Blacklist.t
@@ -71,9 +71,9 @@ for my $Test (@Tests) {
     # run Dev::UnitTest::Run
     my ( $ResultStdout, $ResultStderr, $ExitCode );
     {
-        local *STDOUT;
+        local *STDOUT;                                       ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDOUT, '>:encoding(UTF-8)', \$ResultStdout;    ## no critic qw(OTOBO::ProhibitOpen)
-        local *STDERR;
+        local *STDERR;                                       ## no critic qw(Variables::RequireInitializationForLocalVars)
         open STDERR, '>:encoding(UTF-8)', \$ResultStderr;    ## no critic qw(OTOBO::ProhibitOpen)
 
         $ExitCode = $CommandObject->Execute( '--test', $Test->{Test}, '--quiet' );


### PR DESCRIPTION
…ocalVars

Either with a 'no critic' directive
or by assigning a value in same line as declaration with 'local'.