### PR TITLE
Update Framework.xml in for the dashboard widget News 

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -7958,7 +7958,7 @@ via the Preferences button after logging in.
                 <Item Key="Description" Translatable="1">News about OTOBO.</Item>
                 <Item Key="Block">ContentSmall</Item>
                 <Item Key="Limit">6</Item>
-                <Item Key="Group"></Item>
+                <Item Key="Group">admin</Item>
                 <Item Key="Default">1</Item>
                 <Item Key="CacheTTL">360</Item>
                 <Item Key="Mandatory">0</Item>


### PR DESCRIPTION
OTOBO News only relevant for system administrators. Therefore I added the group "admin" by default to the Dashboard Widget "0405-News".