### PR TITLE
Issue #2131: Also hide quick close button when acl CLoseParentAfterCl…

### DIFF
--- a/Kernel/System/Ticket/Acl/CloseParentAfterClosedChilds.pm
+++ b/Kernel/System/Ticket/Acl/CloseParentAfterClosedChilds.pm
@@ -107,7 +107,7 @@ sub Run {
                 Ticket => {
                     State => $Param{Config}->{State},
                 },
-                Action => ['AgentTicketClose'],
+                Action => ['AgentTicketClose', 'AgentTicketQuickClose'],
             },
         };
     }


### PR DESCRIPTION
…osedChilds is activated.

Assuming that action AgentTicketQuickClose should also be hide.

Fixing #2131 