### PR TITLE
Issue #2177: TidyAll::Plugin::OTOBO::Perl::Dumper is gone

### DIFF
--- a/Kernel/Modules/AdminProcessManagement.pm
+++ b/Kernel/Modules/AdminProcessManagement.pm
@@ -16,15 +16,13 @@
 
 package Kernel::Modules::AdminProcessManagement;
 
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
-
+use v5.24;
 use strict;
 use warnings;
-use v5.24;
 use utf8;
 
 # core modules
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 
 # CPAN modules
 

--- a/Kernel/System/Log.pm
+++ b/Kernel/System/Log.pm
@@ -18,7 +18,6 @@ package Kernel::System::Log;
 
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::PODSpelling)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::Time)
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::Require)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::ParamObject)
 
@@ -417,7 +416,7 @@ dump a perl variable to log
 sub Dumper {
     my ( $Self, @Data ) = @_;
 
-    require Data::Dumper;
+    require Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 
     # returns the context of the current subroutine and sub-subroutine!
     my ( $Package1, $Filename1, $Line1, $Subroutine1 ) = caller(0);

--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -15,7 +15,6 @@
 # --
 
 package Kernel::System::Main;
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::Require)
 
 use strict;
@@ -23,7 +22,7 @@ use warnings;
 
 # core modules
 use Digest::MD5 qw(md5_hex);
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 use File::stat;
 use Unicode::Normalize;
 use List::Util qw(first);

--- a/Kernel/System/MigrateFromOTRS/Base.pm
+++ b/Kernel/System/MigrateFromOTRS/Base.pm
@@ -15,7 +15,6 @@
 # --
 
 package Kernel::System::MigrateFromOTRS::Base;
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
 ## nofilter(TidyAll::Plugin::OTOBO::Common::CustomizationMarkers)
 
 use strict;
@@ -26,7 +25,7 @@ use utf8;
 
 # core modules
 use List::Util qw(first);
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 use File::Basename qw(basename dirname fileparse);
 use File::Copy qw(move);
 use File::Path qw(make_path);

--- a/bin/psgi-bin/otobo.psgi
+++ b/bin/psgi-bin/otobo.psgi
@@ -72,14 +72,13 @@ use lib "$Bin/../..";
 use lib "$Bin/../../Kernel/cpan-lib";
 use lib "$Bin/../../Custom";
 
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::Require)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::SyntaxCheck)
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::Time)
 
 # core modules
 use Cwd qw(abs_path);
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 use Encode qw(:all);
 use File::Basename qw(dirname);
 use File::Path qw(make_path);

--- a/development/webservices/otobo.RESTRequest.pl
+++ b/development/webservices/otobo.RESTRequest.pl
@@ -19,8 +19,6 @@ use strict;
 use warnings;
 use utf8;
 
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
-
 # use ../ as lib location
 use File::Basename;
 use FindBin qw($RealBin);
@@ -28,7 +26,7 @@ use lib dirname($RealBin);
 
 use JSON;
 use REST::Client;
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 
 # This is the HOST for the web service the format is:
 # <HTTP_TYPE>:://<OTOBO_FQDN>/nph-genericinterface.pl

--- a/development/webservices/otobo.SOAPRequest.pl
+++ b/development/webservices/otobo.SOAPRequest.pl
@@ -18,15 +18,13 @@
 use strict;
 use warnings;
 
-## nofilter(TidyAll::Plugin::OTOBO::Perl::Dumper)
-
 # use ../ as lib location
 use File::Basename;
 use FindBin qw($RealBin);
 use lib dirname($RealBin);
 
 use SOAP::Lite;
-use Data::Dumper;
+use Data::Dumper;    ## no critic qw(Modules::ProhibitEvilModules)
 
 # Variables to be defined
 

--- a/scripts/test/XML.t
+++ b/scripts/test/XML.t
@@ -20,7 +20,6 @@ use warnings;
 use utf8;
 
 # core modules
-use Data::Dumper;
 
 # CPAN modules
 use Test2::V0;
@@ -75,7 +74,6 @@ END_XML
 
     my @XMLHash = $XMLObject->XMLParse2XMLHash( String => $String );
 
-    #diag Dumper( \@XMLHash );
     my @ExpectedXMLHash = (
         undef,
         {
@@ -194,8 +192,6 @@ END_XML
 
     # the method MLHash2D() changes the passed in XMLHash as a side effect
     my %ValueHash = $XMLObject->XMLHash2D( XMLHash => \@XMLHash );
-
-    #diag Dumper( \@XMLHash, \%ValueHash );
 
     my @ExpectedChangedXMLHash = (
         undef,
@@ -1200,8 +1196,6 @@ else {
 {
     my $XML      = '<Test Name="test123" />';
     my @XMLARRAY = $XMLObject->XMLParse( String => $XML );
-
-    #diag Dumper($XML, \@XMLARRAY);
 
     # make a copy of the XMLArray (deep clone it),
     # it will be needed for a later comparison


### PR DESCRIPTION
replaced by the Perl::Critic policy Modules::ProhibitEvilModules