### PR TITLE
Issue #727: remove workaround for button_up()

### DIFF
--- a/Kernel/System/UnitTest/Selenium.pm
+++ b/Kernel/System/UnitTest/Selenium.pm
@@ -16,9 +16,9 @@
 
 package Kernel::System::UnitTest::Selenium;
 
+use v5.24;
 use strict;
 use warnings;
-use v5.24;
 use namespace::autoclean;
 use utf8;
 
@@ -235,48 +235,6 @@ sub BUILD {
     $Self->LogExecuteCommandActive($PrevLogExecuteCommandActive);
 
     return;
-}
-
-=head2 button_up()
-
-In L<Selenium::Remote::Driver> 1.39 there seems to be a bug in the method C<button_up()>.
-In the original version the the type of the action is I<Pointer Down>.
-But the action I<Pointer Up> makes more sense and fixes DragAndDrop test failures.
-Therefore override that subroutine.
-
-=cut
-
-sub button_up {
-
-    my ($Self) = @_;
-
-    if (
-        $Self->{is_wd3}
-        && !( grep { $Self->browser_name() eq $_ } qw{MicrosoftEdge} )
-        )
-    {
-        my $Params = {
-            actions => [
-                {
-                    type       => "pointer",
-                    id         => 'mouse',
-                    parameters => { "pointerType" => "mouse" },
-                    actions    => [
-                        {
-                            type     => "pointerUp",
-                            duration => 0,
-                            button   => 0,
-                        },
-                    ],
-                }
-            ],
-        };
-        Selenium::Remote::Driver::_queue_action(%$Params);
-
-        return 1;
-    }
-
-    return $Self->_execute_command( { 'command' => 'buttonUp' } );
 }
 
 =head2 RunTest()

--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -1025,7 +1025,7 @@ my @NeededModules = (
     # Feature devel:test
     {
         Module          => 'Selenium::Remote::Driver',
-        VersionRequired => '1.40',
+        VersionRequired => '1.49',
         Features        => ['devel:test'],
         Comment         => 'used by Kernel::System::UnitTest::Selenium',
         InstTypes       => {

--- a/cpanfile
+++ b/cpanfile
@@ -149,7 +149,7 @@ feature 'devel:encoding', 'Modules for debugging encoding issues' => sub {
 
 feature 'devel:test', 'Modules for running the test suite' => sub {
     # used by Kernel::System::UnitTest::Selenium
-    requires 'Selenium::Remote::Driver', ">= 1.40";
+    requires 'Selenium::Remote::Driver', ">= 1.49";
 
     # a quick compile check
     requires 'Test::Compile';
@@ -333,7 +333,7 @@ feature 'optional', 'Support for feature optional' => sub {
     requires 'String::Dump';
 
     # used by Kernel::System::UnitTest::Selenium
-    requires 'Selenium::Remote::Driver', ">= 1.40";
+    requires 'Selenium::Remote::Driver', ">= 1.49";
 
     # a quick compile check
     requires 'Test::Compile';

--- a/cpanfile.docker
+++ b/cpanfile.docker
@@ -143,7 +143,7 @@ requires 'Const::Fast';
 
 # feature 'devel:test', 'Modules for running the test suite' => sub {
     # used by Kernel::System::UnitTest::Selenium
-    requires 'Selenium::Remote::Driver', ">= 1.40";
+    requires 'Selenium::Remote::Driver', ">= 1.49";
 
     # a quick compile check
     requires 'Test::Compile';


### PR DESCRIPTION
Possible with the brand new version Selenium::Remote::Driver 1.49