### PR TITLE
Issue #2303: The relevant version includes the minor part

### DIFF
--- a/Kernel/Modules/AdminSystemConfiguration.pm
+++ b/Kernel/Modules/AdminSystemConfiguration.pm
@@ -621,22 +621,22 @@ sub Run {
             return $LayoutObject->SecureMode();
         }
 
-        my $ManualVersion = $Kernel::OM->Get('Kernel::Config')->Get('Version');
-        $ManualVersion =~ m{^(\d{1,2}).+};
-        $ManualVersion = $1;
+        # generate version for links to the manual,
+        # only major and minor version are relevant, like 11.0 for version 11.0.1
+        my ($ManualVersion) = $Kernel::OM->Get('Kernel::Config')->Get('Version') =~ m/^(\d{2}\.\d+)/;
 
-        my $Output = $LayoutObject->Header();
-        $Output .= $LayoutObject->NavigationBar();
-        $Output .= $LayoutObject->Output(
-            TemplateFile => 'AdminSystemConfiguration',
-            Data         => {
-                ManualVersion => $ManualVersion,
-                SettingCount  => scalar @SettingList,
-                %OutputData,
-            },
-        );
-        $Output .= $LayoutObject->Footer();
-        return $Output;
+        return join '',
+            $LayoutObject->Header,
+            $LayoutObject->NavigationBar,
+            $LayoutObject->Output(
+                TemplateFile => 'AdminSystemConfiguration',
+                Data         => {
+                    ManualVersion => $ManualVersion,
+                    SettingCount  => scalar @SettingList,
+                    %OutputData,
+                },
+            ),
+            $LayoutObject->Footer;
     }
 }
 

--- a/Kernel/Modules/AgentStatistics.pm
+++ b/Kernel/Modules/AgentStatistics.pm
@@ -809,10 +809,9 @@ sub AddScreen {
         $Frontend{ShowFormInitially} = 1;
     }
 
-    # generate manual link
-    my $ManualVersion = $Kernel::OM->Get('Kernel::Config')->Get('Version');
-    $ManualVersion =~ m{^(\d{1,2}).+};
-    $ManualVersion = $1;
+    # generate version for links to the manual,
+    # only major and minor version are relevant, like 11.0 for version 11.0.1
+    my ($ManualVersion) = $Kernel::OM->Get('Kernel::Config')->Get('Version') =~ m/^(\d{2}\.\d+)/;
 
     # build output
     return join '',

--- a/Kernel/Output/HTML/NavBar/ModuleAdmin.pm
+++ b/Kernel/Output/HTML/NavBar/ModuleAdmin.pm
@@ -42,10 +42,9 @@ sub Run {
     # get config object
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
-    # generate manual link
-    my $ManualVersion = $ConfigObject->Get('Version');
-    $ManualVersion =~ m{^(\d{1,2}).+};
-    $ManualVersion = $1;
+    # generate version for links to the manual,
+    # only major and minor version are relevant, like 11.0 for version 11.0.1
+    my ($ManualVersion) = $ConfigObject->Get('Version') =~ m/^(\d{2}\.\d+)/;
 
     # get all Frontend::Module
     my %NavBarModule;

--- a/Kernel/Output/HTML/Templates/Standard/AdminSystemConfiguration.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSystemConfiguration.tt
@@ -16,7 +16,12 @@
 
 [%
     SET DocumentationLinkText  = Translate('online administrator documentation');
-    SET DocumentationLink      = "<a href='https://doc.otobo.org/manual/admin/10.1/en/content/administration/system-configuration.html' target='_blank'>" _ DocumentationLinkText.html() _ "</a>";
+    SET DocumentationLink      = ""
+        _ "<a href='https://doc.otobo.org/manual/admin/"
+        _ Data.ManualVersion
+        _ "/en/content/administration/system-configuration.html' target='_blank'>"
+        _ DocumentationLinkText.html()
+        _ "</a>";
 %]
 
 <div class="MainBox ARIARoleMain LayoutFixedSidebar SidebarFirst">


### PR DESCRIPTION
Like 11.0 for the full version 11.0.1.
Make sure the match veriables are use that come from previous matches. Aktually use the extracted data in AdminSystemConfiguration.tt.