### PR TITLE
Issue #2425 fixed wrong keys to set user initials string

### DIFF
--- a/Kernel/Output/HTML/TicketOverview/CustomerList.pm
+++ b/Kernel/Output/HTML/TicketOverview/CustomerList.pm
@@ -173,7 +173,7 @@ sub Run {
             $Avatar = '//www.gravatar.com/avatar/' . md5_hex( lc $CustomerUser{UserEmail} ) . '?s=100&d=' . $DefaultIcon;
         }
         else {
-            $UserInitials = substr( $CustomerUser{UserFirstName}, 0, 1 ) . substr( $CustomerUser{UserLastName}, 0, 1 );
+            $UserInitials = substr( $CustomerUser{UserFirstname}, 0, 1 ) . substr( $CustomerUser{UserLastname}, 0, 1 );
         }
 
         # gather categories to be shown


### PR DESCRIPTION
Fixed wrong keys. 

User initials are now shown in customer dashboard in the list of tickets

![image](https://github.com/RotherOSS/otobo/assets/11646726/cad84321-0c6d-4cc9-955f-c46b5751d7d8)
