### PR TITLE
Issue #2315: Fix NamespaceFilter=undef and be consistent with redirect URLS

### DIFF
--- a/Kernel/Modules/AdminDynamicField.pm
+++ b/Kernel/Modules/AdminDynamicField.pm
@@ -363,13 +363,16 @@ sub _ShowOverview {
             },
         );
     }
-    if ( IsStringWithData($NamespaceFilter) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $NamespaceFilter,
-            },
-        );
+
+    if ( IsArrayRefWithData($Namespaces) ) {
+        if ( IsStringWithData($NamespaceFilter) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $NamespaceFilter,
+                },
+            );
+        }
     }
 
     # print the list of dynamic fields

--- a/Kernel/Modules/AdminDynamicFieldAgent.pm
+++ b/Kernel/Modules/AdminDynamicFieldAgent.pm
@@ -580,6 +580,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -588,32 +607,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -835,13 +835,15 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldCheckbox.pm
+++ b/Kernel/Modules/AdminDynamicFieldCheckbox.pm
@@ -537,6 +537,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -545,32 +564,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -781,13 +781,15 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldContactWD.pm
+++ b/Kernel/Modules/AdminDynamicFieldContactWD.pm
@@ -668,6 +668,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # If the user would like to continue editing the dynamic field, just redirect to the change screen.
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -676,32 +695,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -980,13 +980,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     $Output .= $LayoutObject->Output(

--- a/Kernel/Modules/AdminDynamicFieldCustomerCompany.pm
+++ b/Kernel/Modules/AdminDynamicFieldCustomerCompany.pm
@@ -579,6 +579,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -587,32 +606,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -821,13 +821,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldCustomerUser.pm
+++ b/Kernel/Modules/AdminDynamicFieldCustomerUser.pm
@@ -559,6 +559,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString;
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -567,32 +586,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -788,13 +788,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldDB.pm
+++ b/Kernel/Modules/AdminDynamicFieldDB.pm
@@ -580,6 +580,25 @@ sub _ChangeAction {
         Type => 'DynamicFieldDB',
     );
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # If the user would like to continue editing the dynamic field, just redirect to the change screen.
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -588,32 +607,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -1103,13 +1103,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     $Output .= $LayoutObject->Output(

--- a/Kernel/Modules/AdminDynamicFieldDateTime.pm
+++ b/Kernel/Modules/AdminDynamicFieldDateTime.pm
@@ -595,6 +595,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -603,32 +622,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -881,13 +881,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldDropdown.pm
+++ b/Kernel/Modules/AdminDynamicFieldDropdown.pm
@@ -646,6 +646,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -654,32 +673,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 

--- a/Kernel/Modules/AdminDynamicFieldLens.pm
+++ b/Kernel/Modules/AdminDynamicFieldLens.pm
@@ -657,6 +657,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -665,32 +684,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -934,13 +934,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldMultiselect.pm
+++ b/Kernel/Modules/AdminDynamicFieldMultiselect.pm
@@ -651,6 +651,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -659,32 +678,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -1015,13 +1015,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldReference.pm
+++ b/Kernel/Modules/AdminDynamicFieldReference.pm
@@ -653,6 +653,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = '';
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -661,32 +680,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -950,13 +950,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldScript.pm
+++ b/Kernel/Modules/AdminDynamicFieldScript.pm
@@ -651,6 +651,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = "Action=AdminDynamicField";
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -659,32 +678,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -991,13 +991,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldSet.pm
+++ b/Kernel/Modules/AdminDynamicFieldSet.pm
@@ -639,6 +639,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = "Action=AdminDynamicField";
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -647,32 +666,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -893,13 +893,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldText.pm
+++ b/Kernel/Modules/AdminDynamicFieldText.pm
@@ -678,6 +678,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = "Action=AdminDynamicField";
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -686,32 +705,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -1032,13 +1032,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldTitle.pm
+++ b/Kernel/Modules/AdminDynamicFieldTitle.pm
@@ -575,6 +575,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = "Action=AdminDynamicField";
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # if the user would like to continue editing the dynamic field, just redirect to the change screen
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -583,32 +602,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -864,13 +864,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     # generate output

--- a/Kernel/Modules/AdminDynamicFieldWebService.pm
+++ b/Kernel/Modules/AdminDynamicFieldWebService.pm
@@ -657,6 +657,25 @@ sub _ChangeAction {
         );
     }
 
+    my $FilterString = "Action=AdminDynamicField";
+
+    if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
+        $FilterString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{ObjectTypeFilter},
+            },
+        );
+    }
+    if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
+        $FilterString .= ";NamespaceFilter=" . $LayoutObject->Output(
+            Template => '[% Data.Filter | uri %]',
+            Data     => {
+                Filter => $GetParam{NamespaceFilter},
+            },
+        );
+    }
+
     # If the user would like to continue editing the dynamic field, just redirect to the change screen.
     if (
         defined $ParamObject->GetParam( Param => 'ContinueAfterSave' )
@@ -665,32 +684,13 @@ sub _ChangeAction {
     {
         return $LayoutObject->Redirect(
             OP =>
-                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID"
+                "Action=$Self->{Action};Subaction=Change;ObjectType=$DynamicFieldData->{ObjectType};FieldType=$DynamicFieldData->{FieldType};ID=$FieldID$FilterString"
         );
     }
     else {
 
-        my $RedirectString = "Action=AdminDynamicField";
-
-        if ( IsStringWithData( $GetParam{ObjectTypeFilter} ) ) {
-            $RedirectString .= ";ObjectTypeFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{ObjectTypeFilter},
-                },
-            );
-        }
-        if ( IsStringWithData( $GetParam{NamespaceFilter} ) ) {
-            $RedirectString .= ";NamespaceFilter=" . $LayoutObject->Output(
-                Template => '[% Data.Filter | uri %]',
-                Data     => {
-                    Filter => $GetParam{NamespaceFilter},
-                },
-            );
-        }
-
         # otherwise return to overview
-        return $LayoutObject->Redirect( OP => $RedirectString );
+        return $LayoutObject->Redirect( OP => "Action=AdminDynamicField$FilterString" );
     }
 }
 
@@ -768,7 +768,6 @@ sub _ShowScreen {
     );
 
     my $NamespaceList = $Kernel::OM->Get('Kernel::Config')->Get('DynamicField::Namespaces');
-
     if ( IsArrayRefWithData($NamespaceList) ) {
         my $NamespaceStrg = $LayoutObject->BuildSelection(
             Data          => $NamespaceList,
@@ -1021,13 +1020,16 @@ sub _ShowScreen {
             },
         );
     }
-    if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
-        $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
-            Template => '[% Data.Filter | uri %]',
-            Data     => {
-                Filter => $Param{NamespaceFilter},
-            },
-        );
+
+    if ( IsArrayRefWithData($NamespaceList) ) {
+        if ( IsStringWithData( $Param{NamespaceFilter} ) ) {
+            $FilterStrg .= ";NamespaceFilter=" . $LayoutObject->Output(
+                Template => '[% Data.Filter | uri %]',
+                Data     => {
+                    Filter => $Param{NamespaceFilter},
+                },
+            );
+        }
     }
 
     $Output .= $LayoutObject->Output(


### PR DESCRIPTION
Namespace filter url param is only added when namespaces are defined.

Filters are now also appended to redirect url of 'Save' button, not only 'Save and Continue'.

Referencing #2315 