### PR TITLE
Invalid agents can be included in ticket search via sysconfig option.

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -120,6 +120,13 @@
             <Item ValueType="Entity" ValueEntityType="Type" Translatable="1">Unclassified</Item>
         </Value>
     </Setting>
+    <Setting Name="Ticket::Search###IncludeInvalidAgents" Required="0" Valid="0">
+        <Description Translatable="1">When searching for tickets in agent attributes, include invalid agents.</Description>
+        <Navigation>Core::Ticket</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::Service" Required="1" Valid="1">
         <Description Translatable="1">Allows defining services and SLAs for tickets (e. g. email, desktop, network, ...), and escalation attributes for SLAs (if ticket service/SLA feature is enabled).</Description>
         <Navigation>Core::Ticket</Navigation>

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1902,7 +1902,7 @@ sub Run {
             Type  => 'Long',
             Valid => 0,
         );
-        if ( !$ConfigObject->Get('Ticket::ChangeOwnerToEveryone') ) {
+        if ( !$ConfigObject->Get('Ticket::ChangeOwnerToEveryone') && !$ConfigObject->Get('Ticket::Search')->{IncludeInvalidAgents} ) {
             my %Involved = $Kernel::OM->Get('Kernel::System::Group')->PermissionUserInvolvedGet(
                 UserID => $Self->{UserID},
                 Type   => 'ro',


### PR DESCRIPTION
For rel-10_1, see package proposal [here](https://git.gedankenblogsammlung.de/demiguise/ticketsearch-includeinvalidagents).