### PR TITLE
Issue #2240: Render Reply button only if queue allows FollowUp.

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -2325,6 +2325,9 @@ sub _Mask {
             $Param{Subject} = "Re: " . ( $Param{Title} // '' );
         }
         $LayoutObject->Block(
+            Name => 'ReplyButton',
+        );
+        $LayoutObject->Block(
             Name => 'FollowUp',
             Data => \%Param,
         );

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketZoom.tt
@@ -31,7 +31,11 @@
         <div class='oooInfoBlock'>
             <p class='oooInfo ooo12'><i class="ooofo ooofo-info"></i> <span>[% Translate('Information') | html %]</span></p>
         </div>
+        <div>
+[% RenderBlockStart("ReplyButton") %]
         <button id="ReplyButton" class="DontPrint oooM"><span>[% Translate("Reply") | html %] </span><i class="ooofo ooofo-arrow_r2"></i></button>
+[% RenderBlockEnd("ReplyButton") %]
+        </div>
         <i class="ooofo ooofo-more_v"></i>
         <div id='oooCategories'>
 [% RenderBlockStart("Categories") %]


### PR DESCRIPTION
# Screenshots to compare

## Before

### Open ticket

![Auswahl_026](https://github.com/RotherOSS/otobo/assets/46650328/5c2ee6d8-3dab-4ad5-9df9-4e970049e997)

### Closed ticket, FollowUp allowed

![Auswahl_024](https://github.com/RotherOSS/otobo/assets/46650328/71e76b17-bf1f-4868-a41e-82e047004b27)

### Closed ticket, FollowUp denied

![Auswahl_025](https://github.com/RotherOSS/otobo/assets/46650328/24ae79e5-6b13-49a2-bf39-653ed57e98a6)

## After

### Open ticket

![Auswahl_027](https://github.com/RotherOSS/otobo/assets/46650328/08b1f63d-88ac-4ae0-903b-31b5befc56a0)

### Closed ticket, FollowUp allowed

![Auswahl_028](https://github.com/RotherOSS/otobo/assets/46650328/bc4a8dae-383d-41c7-a3a3-69473b4657b7)

### Closed ticket, FollowUp denied

![Auswahl_029](https://github.com/RotherOSS/otobo/assets/46650328/241def70-f727-4542-9fa2-74b40c38cc90)

Closing #2240 