### PR TITLE
Issue #779: Delete last reset time of customer user password only if password is not empty.

### DIFF
--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -371,7 +371,7 @@ sub Run {
                 );
             }
 
-            if ( $CurrentUserData{UserPassword} ne $GetParam{UserPassword} ) {
+            if ( $GetParam{UserPassword} && $CurrentUserData{UserPassword} ne $GetParam{UserPassword} ) {
 
                 $UpdateSuccess = $CustomerUserObject->DeleteOnePreference(
                     Key    => 'UserLastPwChangeTime',


### PR DESCRIPTION
Closing #779 