### PR TITLE
Issue #2548: put DBD::mysql 5.001 on the blacklist

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -533,12 +533,17 @@ my @NeededModules = (
 
     # Feature db
     {
-        Module             => 'DBD::mysql',
-        Required           => 0,
-        Features           => ['db:mysql'],
-        Comment            => 'Required to connect to a MySQL database.',
-        DockerExactVersion => '4.050',
-        InstTypes          => {
+        Module               => 'DBD::mysql',
+        Required             => 0,
+        Features             => ['db:mysql'],
+        Comment              => 'Required to connect to a MariaDB or MySQL database.',
+        VersionsNotSupported => [
+            {
+                Version => '5.001',
+                Comment => q{This version can't be installed with the MariaDB client library.},
+            },
+        ],
+        InstTypes => {
             aptget => 'libdbd-mysql-perl',
             emerge => 'dev-perl/DBD-mysql',
             zypper => 'perl-DBD-mysql',

--- a/cpanfile
+++ b/cpanfile
@@ -72,8 +72,9 @@ feature 'apache:mod_perl', 'Suppport for apache:mod_perl' => sub {
 };
 
 feature 'db:mysql', 'Support for database MySQL' => sub {
-    # Required to connect to a MySQL database.
-    requires 'DBD::mysql';
+    # Required to connect to a MariaDB or MySQL database.
+    # Version 5.001 not supported: This version can't be installed with the MariaDB client library.
+    requires 'DBD::mysql', "!= 5.001";
 
 };
 
@@ -202,8 +203,9 @@ feature 'mail:ssl', 'Suppport for mail:ssl' => sub {
 };
 
 feature 'optional', 'Suppport for optional' => sub {
-    # Required to connect to a MySQL database.
-    requires 'DBD::mysql';
+    # Required to connect to a MariaDB or MySQL database.
+    # Version 5.001 not supported: This version can't be installed with the MariaDB client library.
+    requires 'DBD::mysql', "!= 5.001";
 
     # Required to connect to a MS-SQL database.
     # Version 1.23 not supported: This version is broken and not useable! Please upgrade to a higher version.

--- a/cpanfile.docker
+++ b/cpanfile.docker
@@ -63,8 +63,9 @@ requires 'Unicode::Collate';
 
 
 # feature 'db:mysql', 'Support for database MySQL' => sub {
-    # Required to connect to a MySQL database.
-    requires 'DBD::mysql', "== 4.050";
+    # Required to connect to a MariaDB or MySQL database.
+    # Version 5.001 not supported: This version can't be installed with the MariaDB client library.
+    requires 'DBD::mysql', "!= 5.001";
 
 # };
 


### PR DESCRIPTION
As it can't be compiled neither on Debian 10 Buster nor on Debian 12 Bookworm with default-mysql-client installed.