### PR TITLE
Issue #2371: revert changes in the Get() method

### DIFF
--- a/var/httpd/htdocs/js/Core.Config.js
+++ b/var/httpd/htdocs/js/Core.Config.js
@@ -85,12 +85,20 @@ Core.Config = (function (TargetNS) {
      * @memberof Core.Config
      * @function
      * @returns {Object} The value of the option. Can be every kind of javascript variable type. Returns undefined if setting could not be found.
-     * @param {String} Key            - The name of the config option. May also be a combined option like Richtext.Width.
-     * @param {Object} [DefaultValue] - If nothing is saved in the config, return this default value. The DefaultValue may be omitted.
+     * @param {String} Key            - The name of the config option. May also
+     *                                  be a combined option like Richtext.Width.
+     * @param {Object} [DefaultValue] - If nothing or a false value is saved in the config
+     *                                  then this default value is returned. The DefaultValue may be omitted.
      *                                  In that case undefined is returned.
-     *                                  The saved values 0, '', false are supported.
+     *                                  False values are:
+     *                                    - the undefined value: null
+     *                                    - the number zero:     0
+     *                                    - the false boolean:   false
+     *                                    - the empty string:    ''
+     *                                  Contrary to Perl, the string with the numer zero, '0',
+     *                                  is not false.
      * @description
-     *      Gets a single config value.
+     *      Gets a single config value or a default value or null.
      */
     TargetNS.Get = function (Key, DefaultValue) {
         var Keys = Key.split('.'),
@@ -106,10 +114,10 @@ Core.Config = (function (TargetNS) {
                     // If DefaultValue is not set, this also returns undefined
                     return DefaultValue;
                 }
-                // If we are in the last step of the namespace return the saved value.
-                // If nothing is saved return the default value. The number 0 and the string '' are not nothing.
+                // If we are in the last step of the namespace then return the saved value.
+                // If nothing or a false value is saved then return the default value or null.
                 if (Keys.length === Count + 1) {
-                    return ConfigLevel[ConfigPrefix + Keys[KeyToken]] ?? DefaultValue;
+                    return ConfigLevel[ConfigPrefix + Keys[KeyToken]] || DefaultValue;
                 }
                 // otherwise go one level deeper and try again
                 else {


### PR DESCRIPTION
Returning the default value is now triggered again by the truthiness of the stored value. Note that the string containing the digit 0 is true.