### PR TITLE
Issue #2635: Overwrite sub SearchFieldPreferences to prevent set fields from being used as search fields.

### DIFF
--- a/Kernel/System/DynamicField/Driver/Set.pm
+++ b/Kernel/System/DynamicField/Driver/Set.pm
@@ -732,4 +732,12 @@ sub ValueLookup {
     return join ' - ', @SetValue;
 }
 
+sub SearchFieldPreferences {
+    my ( $Self, %Param ) = @_;
+
+    # this field makes no use of SearchFieldPreferences
+    # nevertheless, function needs to be overwritten to make sure that the call doesn't reach SearchFieldPreferences in BaseSelect
+    return;
+}
+
 1;


### PR DESCRIPTION
Closing #2635 