### PR TITLE
Issue #2630 df valuerender

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldReference.pm
+++ b/Kernel/Modules/AdminDynamicFieldReference.pm
@@ -780,6 +780,7 @@ sub _ShowScreen {
     );
 
     # compute value for editfieldmode to maintain frontend selection
+    $Param{EditFieldMode} //= '';
     $Param{EditFieldMode} = $Param{EditFieldMode} eq 'AutoComplete' ? 'AutoComplete' : ( $Param{Multiselect} ? 'Multiselect' : 'Dropdown' );
 
     # Selections may be set up in a declaritive way

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -635,7 +635,7 @@ sub _RenderAjax {
                         Value              => [ $Param{GetParam}{"DynamicField_$DynamicFieldConfig->{Name}"}[$i] ],
                     ) || $PossibleValues;
 
-                    my $Name = $i ? "DynamicField_$DynamicFieldConfig->{Name}_$i" : "DynamicField_$DynamicFieldConfig->{Name}";
+                    my $Name = "DynamicField_$DynamicFieldConfig->{Name}_$i";
 
                     # add dynamic field to the list of fields to update
                     push @JSONCollector, {

--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -155,7 +155,7 @@ sub Run {
         $Self->{FormID} = $Kernel::OM->Get('Kernel::System::Web::UploadCache')->FormIDCreate();
     }
 
-    # if invalid process is detected on a ActivityDilog popup screen show an error message
+    # if invalid process is detected on a ActivityDialog popup screen show an error message
     if (
         $Self->{Subaction} eq 'DisplayActivityDialog'
         && !$FollowupProcessList->{$ProcessEntityID}
@@ -3243,6 +3243,7 @@ sub _StoreActivityDialog {
                 ObjectID           => $TicketID,
                 Value              => $TicketParam{$CurrentField},
                 UserID             => $ConfigObject->Get('CustomerPanelUserID'),
+                ProcessSuffix      => $Self->{IDSuffix},
             );
             if ( !$Success ) {
                 $LayoutObject->CustomerFatalError(

--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -744,6 +744,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/BaseScript.pm
+++ b/Kernel/System/DynamicField/Driver/BaseScript.pm
@@ -660,6 +660,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -879,7 +879,7 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
-    # convert undef to empty string
+    # prevent joining undefined values
     @Values = map { $_ // '' } @Values;
 
     # set item separator

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -786,6 +786,7 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
     @Values = map { $_ // '' } @Values;
 
     # set item separator

--- a/Kernel/System/DynamicField/Driver/Date.pm
+++ b/Kernel/System/DynamicField/Driver/Date.pm
@@ -820,6 +820,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # only keep date part, loose time part of time-stamp
     for my $ValueItem (@Values) {
         if ($ValueItem) {

--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -401,6 +401,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -120,6 +120,7 @@ sub ValueSet {
         ObjectID               => $Param{ObjectID},
         LensDynamicFieldConfig => $LensDFConfig,
         EditFieldValue         => 1,
+        ProcessSuffix          => $Param{ProcessSuffix},
     );
 
     return unless $ReferencedObjectID;
@@ -564,7 +565,7 @@ sub BuildSelectionDataGet {
 
 Methods that are used only internally.
 
-=head2 _GetReferencedObjectID()
+=head2 _GetReferenceDFConfig()
 
 The ID of the referenced object.
 
@@ -617,6 +618,10 @@ sub _GetReferencedObjectID {
     my $ReferenceDFConfig = $Self->_GetReferenceDFConfig(
         LensDynamicFieldConfig => $LensDFConfig,
     );
+
+    # in case we have a process suffix, append it to the name
+    $Param{ProcessSuffix} //= '';
+    $ReferenceDFConfig->{Name} .= $Param{ProcessSuffix};
 
     if ( $Param{EditFieldValue} ) {
 

--- a/Kernel/System/DynamicField/Driver/Reference.pm
+++ b/Kernel/System/DynamicField/Driver/Reference.pm
@@ -570,6 +570,7 @@ sub DisplayValueRender {
 
     VALUEITEM:
     for my $ReadableValue (@LongObjectDescriptions) {
+        $ReadableValue //= '';
         my $ReadableLength = length $ReadableValue;
 
         # set title equal value
@@ -799,11 +800,11 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
-
-    # convert undef to empty string
-    @Values = map { $_ // '' } @Values;
 
     # Output transformations
     $Value = join( $ItemSeparator, @Values );

--- a/Kernel/System/DynamicField/Driver/WebService.pm
+++ b/Kernel/System/DynamicField/Driver/WebService.pm
@@ -720,6 +720,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 


### PR DESCRIPTION
Referencing #2630 

This PR holds multiple small but relevant changes. I will try to give a brief summary:

- As I encountered the problem of using undefined values in DisplayValueRender and ReadableValueRender multiple times, I took the freedom to align the handling at every relevant occurrence with the drivers where it works
- CustomerTicketProcess now passes its process suffix to ValueSet - this is because for Lens fields, EditFieldValueGet is called during the procedure and this fails to retrieve the value from the web request without the process suffix
- AgentTicketProcess assumed in its AJAXUpdate handling that the first input of multivalue fields still has no index (DynamicField_Name vs. DynamicField_Name_0) as it has been before - I adapted the behavior to the current naming
- When adding a new reference dynamic field, EditFieldMode is undef which caused a warning in the log - for this case, I changed the value to an empty string
- Adjusted some POD and comments