### PR TITLE
Issue #2630 miscellaneous df stuff

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldReference.pm
+++ b/Kernel/Modules/AdminDynamicFieldReference.pm
@@ -780,6 +780,7 @@ sub _ShowScreen {
     );
 
     # compute value for editfieldmode to maintain frontend selection
+    $Param{EditFieldMode} //= '';
     $Param{EditFieldMode} = $Param{EditFieldMode} eq 'AutoComplete' ? 'AutoComplete' : ( $Param{Multiselect} ? 'Multiselect' : 'Dropdown' );
 
     # Selections may be set up in a declaritive way

--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -635,7 +635,7 @@ sub _RenderAjax {
                         Value              => [ $Param{GetParam}{"DynamicField_$DynamicFieldConfig->{Name}"}[$i] ],
                     ) || $PossibleValues;
 
-                    my $Name = $i ? "DynamicField_$DynamicFieldConfig->{Name}_$i" : "DynamicField_$DynamicFieldConfig->{Name}";
+                    my $Name = "DynamicField_$DynamicFieldConfig->{Name}_$i";
 
                     # add dynamic field to the list of fields to update
                     push @JSONCollector, {

--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -744,6 +744,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/BaseScript.pm
+++ b/Kernel/System/DynamicField/Driver/BaseScript.pm
@@ -660,6 +660,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -879,7 +879,7 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
-    # convert undef to empty string
+    # prevent joining undefined values
     @Values = map { $_ // '' } @Values;
 
     # set item separator

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -786,6 +786,7 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
     @Values = map { $_ // '' } @Values;
 
     # set item separator

--- a/Kernel/System/DynamicField/Driver/Date.pm
+++ b/Kernel/System/DynamicField/Driver/Date.pm
@@ -820,6 +820,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # only keep date part, loose time part of time-stamp
     for my $ValueItem (@Values) {
         if ($ValueItem) {

--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -401,6 +401,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 

--- a/Kernel/System/DynamicField/Driver/Reference.pm
+++ b/Kernel/System/DynamicField/Driver/Reference.pm
@@ -570,6 +570,7 @@ sub DisplayValueRender {
 
     VALUEITEM:
     for my $ReadableValue (@LongObjectDescriptions) {
+        $ReadableValue //= '';
         my $ReadableLength = length $ReadableValue;
 
         # set title equal value
@@ -799,11 +800,11 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
-
-    # convert undef to empty string
-    @Values = map { $_ // '' } @Values;
 
     # Output transformations
     $Value = join( $ItemSeparator, @Values );

--- a/Kernel/System/DynamicField/Driver/WebService.pm
+++ b/Kernel/System/DynamicField/Driver/WebService.pm
@@ -720,6 +720,9 @@ sub ReadableValueRender {
         @Values = ( $Param{Value} );
     }
 
+    # prevent joining undefined values
+    @Values = map { $_ // '' } @Values;
+
     # set new line separator
     my $ItemSeparator = ', ';
 


### PR DESCRIPTION
Referencing #2630

I included the following changes:

- As I encountered the problem of using undefined values in DisplayValueRender and ReadableValueRender multiple times, I took the freedom to align the handling at every relevant occurrence with the drivers where it works
- AgentTicketProcess assumed in its AJAXUpdate handling that the first input of multivalue fields still has no index (DynamicField_Name vs. DynamicField_Name_0) as it has been before - I adapted the behavior to the current naming
- When adding a new reference dynamic field, EditFieldMode is undef which caused a warning in the log - for this case, I changed the value to an empty string