### PR TITLE
Issue #2689: Pass action to TicketAcl sub to enable restricting activity dialogs via acl by frontend action in AgentTicketZoom.

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1618,6 +1618,7 @@ sub MaskAgentZoom {
             my $ACL = $TicketObject->TicketAcl(
                 Data          => \%PermissionActivityDialogList,
                 TicketID      => $Ticket{TicketID},
+                Action        => $Self->{Action},
                 ReturnType    => 'ActivityDialog',
                 ReturnSubType => '-',
                 UserID        => $Self->{UserID},


### PR DESCRIPTION
Closing #2689 