### PR TITLE
Issue #2685: Made check for content less restrictive in EditFieldRender.

### DIFF
--- a/Kernel/Output/HTML/DynamicField/Mask.pm
+++ b/Kernel/Output/HTML/DynamicField/Mask.pm
@@ -98,6 +98,8 @@ creates the field HTML to be used in edit masks for multiple dynamic fields.
 sub EditSectionRender {
     my ( $Self, %Param ) = @_;
 
+    $Param{Content} //= [];
+
     # check needed params
     for my $Needed (qw(Content DynamicFields LayoutObject ParamObject)) {
         if ( !$Param{$Needed} ) {
@@ -110,7 +112,7 @@ sub EditSectionRender {
         }
     }
 
-    if ( !IsArrayRefWithData( $Param{Content} ) ) {
+    if ( ref $Param{Content} ne 'ARRAY' ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => "Invalid content!",

--- a/Kernel/Output/HTML/DynamicField/Mask.pm
+++ b/Kernel/Output/HTML/DynamicField/Mask.pm
@@ -107,7 +107,7 @@ sub EditSectionRender {
     }
 
     # check needed params
-    for my $Needed (qw(Content DynamicFields LayoutObject ParamObject)) {
+    for my $Needed (qw(DynamicFields LayoutObject ParamObject)) {
         if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',

--- a/Kernel/Output/HTML/DynamicField/Mask.pm
+++ b/Kernel/Output/HTML/DynamicField/Mask.pm
@@ -98,7 +98,13 @@ creates the field HTML to be used in edit masks for multiple dynamic fields.
 sub EditSectionRender {
     my ( $Self, %Param ) = @_;
 
-    $Param{Content} //= [];
+    my $TemplateFile = $Param{CustomerInterface} ? 'DynamicField/CustomerEditField' : 'DynamicField/AgentEditField';
+
+    if ( !$Param{Content} ) {
+        return $Param{LayoutObject}->Output(
+            TemplateFile => $TemplateFile,
+        );
+    }
 
     # check needed params
     for my $Needed (qw(Content DynamicFields LayoutObject ParamObject)) {
@@ -112,7 +118,7 @@ sub EditSectionRender {
         }
     }
 
-    if ( ref $Param{Content} ne 'ARRAY' ) {
+    if ( !IsArrayRefWithData( $Param{Content} ) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => "Invalid content!",
@@ -120,8 +126,6 @@ sub EditSectionRender {
 
         return;
     }
-
-    my $TemplateFile = $Param{CustomerInterface} ? 'DynamicField/CustomerEditField' : 'DynamicField/AgentEditField';
 
     my $DynamicFieldBackendObject = $Kernel::OM->Get('Kernel::System::DynamicField::Backend');
 


### PR DESCRIPTION
Closing #2685

Comment: Following a brief discussion with @svenoe, I switched my approach from fixing the modules calling `EditSectionRender` to fixing the function itself to be able to cope with empty content. The following changes seemed appropriate to me:

- Overwriting an undefined value with an empty array ref (most likely, if undefined content is passed, you don't want to render anything)
- The check for content doesn't need to make sure that the array ref contains data, an empty array ref is totally fine