### PR TITLE
Issue #2735: escape the $ in "..$%.."

### DIFF
--- a/scripts/test/ProcessManagement/DB/Activity.t
+++ b/scripts/test/ProcessManagement/DB/Activity.t
@@ -208,7 +208,7 @@ my @Tests = (
         Name   => 'ActivityAdd Test 8: Correct UTF8',
         Config => {
             EntityID => "$RandomID-1",
-            Name     => "Activity-$RandomID-!Â§$%&/()=?Ã*ÃÃL:L@,.-",
+            Name     => "Activity-$RandomID-!Â§\$%&/()=?Ã*ÃÃL:L@,.-",
             Config   => {
                 Description    => 'a Description !Â§$%&/()=?Ã*ÃÃL:L@,.-',
                 ActivityDialog => {
@@ -304,7 +304,7 @@ for my $Test (@Tests) {
     },
     {
         Name         => "ActivitySearch Test2 - Correct UTF8 1",
-        ActivityName => "Activity-$RandomID-!Â§$%&/()=?Ã*ÃÃL:L@,.-",
+        ActivityName => "Activity-$RandomID-!Â§\$%&/()=?Ã*ÃÃL:L@,.-",
         ,
         Result => ["$RandomID-1"],
         Count  => 1,
@@ -718,7 +718,7 @@ for my $Test (@Tests) {
         Config => {
             ID       => $AddedActivityList[1],
             EntityID => $RandomID . '-1-U',
-            Name     => "Activity-$RandomID -!Â§$%&/()=?Ã*ÃÃL:L@,.--U",
+            Name     => "Activity-$RandomID -!Â§\$%&/()=?Ã*ÃÃL:L@,.--U",
             Config   => {
                 Description => 'a Description !Â§$%&/()=?Ã*ÃÃL:L@,.--U',
             },

--- a/scripts/test/ProcessManagement/DB/ActivityDialog.t
+++ b/scripts/test/ProcessManagement/DB/ActivityDialog.t
@@ -256,7 +256,7 @@ my @Tests = (
         Name   => 'ActivityDialogAdd Test 15: Correct UTF8',
         Config => {
             EntityID => "$RandomID-1",
-            Name     => "ActivityDialog-$RandomID-!Â§$%&/()=?Ã*ÃÃL:L@,.-",
+            Name     => "ActivityDialog-$RandomID-!Â§\$%&/()=?Ã*ÃÃL:L@,.-",
             Config   => {
                 DescriptionShort => 'a Description !Â§$%&/()=?Ã*ÃÃL:L@,.-',
                 Fields           => {
@@ -642,7 +642,7 @@ for my $Test (@Tests) {
         Config => {
             ID       => $AddedActivityDialogsList[1],
             EntityID => $RandomID . '-1-U',
-            Name     => "ActivityDialog-$RandomID -!Â§$%&/()=?Ã*ÃÃL:L@,.--U",
+            Name     => "ActivityDialog-$RandomID -!Â§\$%&/()=?Ã*ÃÃL:L@,.--U",
             Config   => {
                 DescriptionShort => 'a Description !Â§$%&/()=?Ã*ÃÃL:L@,.--U',
                 Fields           => {

--- a/scripts/test/ProcessManagement/DB/Process.t
+++ b/scripts/test/ProcessManagement/DB/Process.t
@@ -872,7 +872,7 @@ for my $Test (@Tests) {
         Config => {
             ID            => $AddedProcessList[1],
             EntityID      => $RandomID . '-1-U',
-            Name          => "Process-$RandomID -!Â§$%&/()=?Ã*ÃÃL:L@,.--U",
+            Name          => "Process-$RandomID -!Â§\$%&/()=?Ã*ÃÃL:L@,.--U",
             StateEntityID => 'S1',
             Layout        => {},
             Config        => {

--- a/scripts/test/ProcessManagement/DB/Transition.t
+++ b/scripts/test/ProcessManagement/DB/Transition.t
@@ -250,7 +250,7 @@ my @Tests = (
         Name   => 'TransitionAdd Test 12: Correct UTF8 2',
         Config => {
             EntityID => "$RandomID-2",
-            Name     => "Transition-$RandomID--!Â§$%&/()=?Ã*ÃÃL:L@,.-",
+            Name     => "Transition-$RandomID--!Â§\$%&/()=?Ã*ÃÃL:L@,.-",
             Config   => {
                 Condition => {
                     Type  => 'and',
@@ -634,7 +634,7 @@ for my $Test (@Tests) {
         Config => {
             ID       => $AddedTransitionsList[1],
             EntityID => $RandomID . '-2-U',
-            Name     => "Transition-$RandomID--!Â§$%&/()=?Ã*ÃÃL:L@,.-U",
+            Name     => "Transition-$RandomID--!Â§\$%&/()=?Ã*ÃÃL:L@,.-U",
             Config   => {
                 Condition => {
                     Type  => 'and',

--- a/scripts/test/ProcessManagement/DB/TransitionAction.t
+++ b/scripts/test/ProcessManagement/DB/TransitionAction.t
@@ -236,7 +236,7 @@ my @Tests = (
         Name   => 'TransitionActionAdd Test 14: Correct UTF8 2',
         Config => {
             EntityID => "$RandomID-2",
-            Name     => "TransitionAction-$RandomID--!Â§$%&/()=?Ã*ÃÃL:L@,.",
+            Name     => "TransitionAction-$RandomID--!Â§\$%&/()=?Ã*ÃÃL:L@,.",
             Config   => {
                 Module => 'Kernel::System::Process::Transition::Action::QueueMove',
                 Config => {
@@ -573,7 +573,7 @@ for my $Test (@Tests) {
         Config => {
             ID       => $AddedTransitionActionsList[1],
             EntityID => $RandomID . '-2-U',
-            Name     => "TransitionAction-$RandomID--!Â§$%&/()=?Ã*ÃÃL:L@,.-U",
+            Name     => "TransitionAction-$RandomID--!Â§\$%&/()=?Ã*ÃÃL:L@,.-U",
             Config   => {
                 Module => 'Kernel::System::Process::Transition::Action::QueueMove-U',
                 Config => {


### PR DESCRIPTION
So that $FORMAT_PAGE_NUMBER, usually 0, is not interpolated into the string. Looks like this change does not affect the test results, as in these cases there is no matching against the activity name.