### PR TITLE
Issue #2745: remove useless calls to utf8::upgrade

### DIFF
--- a/Kernel/System/ACL/DB/ACL.pm
+++ b/Kernel/System/ACL/DB/ACL.pm
@@ -137,7 +137,6 @@ sub ACLAdd {
         }
 
         $ConfigMatch = $YAMLObject->Dump( Data => $Param{ConfigMatch} );
-        utf8::upgrade($ConfigMatch);
     }
 
     if ( $Param{ConfigChange} ) {
@@ -151,7 +150,6 @@ sub ACLAdd {
         }
 
         $ConfigChange = $YAMLObject->Dump( Data => $Param{ConfigChange} );
-        utf8::upgrade($ConfigChange);
     }
 
     # get database object
@@ -486,12 +484,10 @@ sub ACLUpdate {
 
     if ( $Param{ConfigMatch} && IsHashRefWithData( $Param{ConfigMatch} ) ) {
         $ConfigMatch = $YAMLObject->Dump( Data => $Param{ConfigMatch} );
-        utf8::upgrade($ConfigMatch);
     }
 
     if ( $Param{ConfigChange} && IsHashRefWithData( $Param{ConfigChange} ) ) {
         $ConfigChange = $YAMLObject->Dump( Data => $Param{ConfigChange} );
-        utf8::upgrade($ConfigChange);
     }
 
     # get database object

--- a/Kernel/System/DynamicField.pm
+++ b/Kernel/System/DynamicField.pm
@@ -157,10 +157,6 @@ sub DynamicFieldAdd {
     # dump config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
-
     my $InternalField = $Param{InternalField} ? 1 : 0;
 
     # sql
@@ -386,13 +382,7 @@ sub DynamicFieldUpdate {
     my $YAMLObject = $Kernel::OM->Get('Kernel::System::YAML');
 
     # dump config as string
-    my $Config = $YAMLObject->Dump(
-        Data => $Param{Config},
-    );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #    part of the data already had it.
-    utf8::upgrade($Config);
+    my $Config = $YAMLObject->Dump( Data => $Param{Config} );
 
     return if !$YAMLObject->Load( Data => $Config );
 

--- a/Kernel/System/ProcessManagement/DB/Activity.pm
+++ b/Kernel/System/ProcessManagement/DB/Activity.pm
@@ -139,10 +139,6 @@ sub ActivityAdd {
     # dump config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
-
     # sql
     return if !$DBObject->Do(
         SQL => '
@@ -463,10 +459,6 @@ sub ActivityUpdate {
 
     # dump config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
 
     # check if need to update db
     return if !$DBObject->Prepare(

--- a/Kernel/System/ProcessManagement/DB/ActivityDialog.pm
+++ b/Kernel/System/ProcessManagement/DB/ActivityDialog.pm
@@ -164,10 +164,6 @@ sub ActivityDialogAdd {
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
-
     # sql
     return if !$DBObject->Do(
         SQL => '
@@ -458,10 +454,6 @@ sub ActivityDialogUpdate {
 
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
 
     # check if need to update db
     return if !$DBObject->Prepare(

--- a/Kernel/System/ProcessManagement/DB/Process.pm
+++ b/Kernel/System/ProcessManagement/DB/Process.pm
@@ -179,11 +179,6 @@ sub ProcessAdd {
     my $Layout = $YAMLObject->Dump( Data => $Param{Layout} );
     my $Config = $YAMLObject->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Layout);
-    utf8::upgrade($Config);
-
     # SQL
     return if !$DBObject->Do(
         SQL => '
@@ -658,11 +653,6 @@ sub ProcessUpdate {
     # dump layout and config as string
     my $Layout = $YAMLObject->Dump( Data => $Param{Layout} );
     my $Config = $YAMLObject->Dump( Data => $Param{Config} );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Layout);
-    utf8::upgrade($Config);
 
     # check if need to update db
     return if !$DBObject->Prepare(

--- a/Kernel/System/ProcessManagement/DB/Transition.pm
+++ b/Kernel/System/ProcessManagement/DB/Transition.pm
@@ -157,10 +157,6 @@ sub TransitionAdd {
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
-
     # sql
     return if !$DBObject->Do(
         SQL => '
@@ -444,10 +440,6 @@ sub TransitionUpdate {
 
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
 
     # check if need to update db
     return if !$DBObject->Prepare(

--- a/Kernel/System/ProcessManagement/DB/TransitionAction.pm
+++ b/Kernel/System/ProcessManagement/DB/TransitionAction.pm
@@ -163,10 +163,6 @@ sub TransitionActionAdd {
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
 
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
-
     # sql
     return if !$DBObject->Do(
         SQL => '
@@ -457,10 +453,6 @@ sub TransitionActionUpdate {
 
     # dump layout and config as string
     my $Config = $Kernel::OM->Get('Kernel::System::YAML')->Dump( Data => $Param{Config} );
-
-    # Make sure the resulting string has the UTF-8 flag. YAML only sets it if
-    #   part of the data already had it.
-    utf8::upgrade($Config);
 
     # check if need to update db
     return if !$DBObject->Prepare(

--- a/Kernel/System/YAML.pm
+++ b/Kernel/System/YAML.pm
@@ -65,6 +65,8 @@ Dump a Perl data structure to a YAML string.
         Data     => $Data,
     );
 
+The generated string is upgraded to have utf8 as its internal representation.
+
 =cut
 
 sub Dump {


### PR DESCRIPTION
The strings from Kernel::System::YAML::Dump() are already upgraded