### PR TITLE
Issue #2670: Added check for possible values hash key before using it.

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -648,6 +648,10 @@ sub _RenderAjax {
             my ($PossibleValuesElement) = grep { $_->{Name} eq 'DynamicField_' . $DynamicFieldConfig->{Name} } values $DynFieldStates{Fields}->%*;
 
             next DIALOGFIELD unless IsHashRefWithData($PossibleValuesElement);
+
+            # In case of ACL restrictions taking place, it can occur that we have a possible values element, but the PossibleValues key is undefined
+            next DIALOGFIELD unless IsHashRefWithData( $PossibleValuesElement->{PossibleValues} );
+
             my %PossibleValues = $PossibleValuesElement->{PossibleValues}->%*;
 
             if ( $DynamicFieldConfig->{Config}{MultiValue} && ref $Param{GetParam}{"DynamicField_$DynamicFieldConfig->{Name}"} eq 'ARRAY' ) {

--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -406,6 +406,10 @@ sub _RenderAjax {
             my ($PossibleValuesElement) = grep { $_->{Name} eq 'DynamicField_' . $DynamicFieldConfig->{Name} } values $DynFieldStates{Fields}->%*;
 
             next DIALOGFIELD unless IsHashRefWithData($PossibleValuesElement);
+
+            # In case of ACL restrictions taking place, it can occur that we have a possible values element, but the PossibleValues key is undefined
+            next DIALOGFIELD unless IsHashRefWithData( $PossibleValuesElement->{PossibleValues} );
+
             my %PossibleValues = $PossibleValuesElement->{PossibleValues}->%*;
 
             if ( $DynamicFieldConfig->{Config}{MultiValue} && ref $Param{GetParam}{"DynamicField_$DynamicFieldConfig->{Name}"} eq 'ARRAY' ) {


### PR DESCRIPTION
In some cases (e.g. DF Database hidden via ACL in AgentTicketProcess),  it can happen that we do have a PossibleValues element, but the PossibleValues hash key is undefined. This has to be catched.

Referencing #2670