### PR TITLE
Issue #2042: Prevent modal dialog from closing when selecting an autocomplete suggestion.

### DIFF
--- a/Kernel/Modules/AgentReferenceSearch.pm
+++ b/Kernel/Modules/AgentReferenceSearch.pm
@@ -1,7 +1,7 @@
 # --
 # OTOBO is a web-based ticketing system for service organisations.
 # --
-# Copyright (C) 2019-2023 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -58,7 +58,11 @@ sub Run {
     if (
         !$Field
         ||
-        $Field !~ m{ \A (?: Autocomplete | Search ) _DynamicField_ (.*?) (?:_[0-9a-f]+)? \z }xms
+
+        # possible constellations:
+        #   Autocomplete_DynamicField_Fieldname
+        #   Autocomplete_Search_DynamicField_Fieldname
+        $Field !~ m{ \A (?: Autocomplete (?: _Search )? ) _DynamicField_ (.*?) (?:_[0-9a-f]+)? \z }xms
         )
     {
         return $LayoutObject->JSONReply(

--- a/Kernel/System/DynamicField/Driver/BaseReference.pm
+++ b/Kernel/System/DynamicField/Driver/BaseReference.pm
@@ -1,7 +1,7 @@
 # --
 # OTOBO is a web-based ticketing system for service organisations.
 # --
-# Copyright (C) 2019-2023 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -592,7 +592,8 @@ sub SearchFieldRender {
     );
 
     my $HTMLString = <<"EOF";
-<input type="text" class="$FieldClass" id="$FieldName" name="$FieldName" title="$FieldLabelEscaped" value="$ValueEscaped" />
+<input type="hidden" id="$FieldName" name="$FieldName" value="$ValueEscaped" />
+<input type="text" class="$FieldClass" id="Autocomplete_$FieldName" name="Autocomplete_$FieldName" title="$FieldLabelEscaped" value="$ValueEscaped" />
 EOF
 
     my $AdditionalText;
@@ -714,7 +715,7 @@ sub ReadableValueRender {
     # get descriptive names for the values, e.g. TicketNumber for TicketID
     my @LongObjectDescriptions;
     {
-        for my $ObjectID ( @Values ) {
+        for my $ObjectID (@Values) {
             if ($ObjectID) {
                 my %Description = $Self->ObjectDescriptionGet(
                     ObjectID => $ObjectID,

--- a/var/httpd/htdocs/js/Core.UI.Dialog.js
+++ b/var/httpd/htdocs/js/Core.UI.Dialog.js
@@ -578,6 +578,9 @@ Core.UI.Dialog = (function (TargetNS) {
                 if (
                     $(event.target).parents('html').length
                     && $(event.target).closest('div.Dialog').length === 0
+
+                    // Case autocomplete dropdown in modal dialogs
+                    // NOTE: currently only occurs when using dynamic field reference search fields in ticket search or config item search
                     && !$(event.target).hasClass('ui-menu-item-wrapper')
                 ) {
                     HandleClosingAction();

--- a/var/httpd/htdocs/js/Core.UI.Dialog.js
+++ b/var/httpd/htdocs/js/Core.UI.Dialog.js
@@ -2,7 +2,7 @@
 // OTOBO is a web-based ticketing system for service organisations.
 // --
 // Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-// Copyright (C) 2019-2023 Rother OSS GmbH, https://otobo.de/
+// Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
 // --
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -575,7 +575,11 @@ Core.UI.Dialog = (function (TargetNS) {
             $(document).off('click.Dialog').on('click.Dialog', function (event) {
                 // If target element is removed before this event triggers, the enclosing div.Dialog can't be found anymore
                 // We check, if we can find a parent HTML element to be sure, that the element is not removed
-                if ($(event.target).parents('html').length && $(event.target).closest('div.Dialog').length === 0) {
+                if (
+                    $(event.target).parents('html').length
+                    && $(event.target).closest('div.Dialog').length === 0
+                    && !$(event.target).hasClass('ui-menu-item-wrapper')
+                ) {
                     HandleClosingAction();
                 }
             });

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
@@ -1149,7 +1149,11 @@ td.Highlight a.ui-state-default {
  */
 
 .ui-autocomplete {
-    /* important necessary because it would otherwise be overwritten by jquery-ui css */
+    /*
+     * z-index for autocomplete dropdowns has the same value as z-index for modernized select dropdowns
+     * compare Core.InputFields.css line 305
+     * important is necessary because it would otherwise be overwritten by jquery-ui css
+     * */
     z-index: 6100 !important;
     max-height: 200px;
     overflow-x: hidden;

--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Default.css
@@ -1,7 +1,7 @@
 /* OTOBO is a web-based ticketing system for service organisations.
 
 Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-Copyright (C) 2019-2023 Rother OSS GmbH, https://otobo.de/
+Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -1149,7 +1149,8 @@ td.Highlight a.ui-state-default {
  */
 
 .ui-autocomplete {
-    z-index: 20 !important;
+    /* important necessary because it would otherwise be overwritten by jquery-ui css */
+    z-index: 6100 !important;
     max-height: 200px;
     overflow-x: hidden;
     overflow-y: scroll;


### PR DESCRIPTION
The problem occured in AgentITSMConfigItemSearch modal dialog. When adding a reference dynamic field to the search params (in this case a ConfigItem reference field), the search field is rendered as autocomplete. Autocomplete suggestion dropdowns are appended at the bottom of the html body, but not inside the modal dialog html. So, when selecting one of the autocomplete suggestions, the dialog closes instantly because an element outside of the dialog was clicked.

To prevent this, I used one of the classes of the autocomplete suggestion items.

Referencing #2042