### PR TITLE
Issue #2498: open the otobo.de links in new tab.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/CustomerFooter.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerFooter.tt
@@ -18,7 +18,7 @@
     <div>
         <div id='oooCopyright'>
             <p class='ooo10g'>© 2019-2024 </p>
-            <a href="https://otobo.de">
+            <a href="https://otobo.de" target="_blank">
                 <svg
                    xmlns:dc="http://purl.org/dc/elements/1.1/"
                    xmlns:cc="http://creativecommons.org/ns#"
@@ -103,7 +103,7 @@
             </a>
         </div>
         <div id='ooo'>
-            <p class='ooo10g'>powered by <a href="https://otobo.de">Rother OSS</a></p>
+            <p class='ooo10g'>powered by <a href="https://otobo.de" target="_blank">Rother OSS</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
These are the links at the bottom of the customer interface. The commented out FooterLinks already open in a new tab.