### PR TITLE
Issue #2887: JS and driver module fixes for dynamic field Database

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -466,14 +466,17 @@ sub EditFieldValueGet {
         && ref $Param{ParamObject} eq 'Kernel::System::Web::Request'
         )
     {
-        my @Data = $Param{ParamObject}->GetArray( Param => $FieldName );
-
-        if ( $Param{DynamicFieldConfig}->{Config}->{MultiValue} ) {
+        if ( $Param{DynamicFieldConfig}{Config}{MultiValue} ) {
+            my @Data = $Param{ParamObject}->GetArray( Param => $FieldName );
 
             # delete the template value
             pop @Data;
+
+            $Value = \@Data;
         }
-        $Value = \@Data;
+        else {
+            $Value = $Param{ParamObject}->GetParam( Param => $FieldName );
+        }
     }
 
     if ( defined $Param{ReturnTemplateStructure} && $Param{ReturnTemplateStructure} eq 1 ) {

--- a/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
+++ b/var/httpd/htdocs/js/Core.Agent.DynamicFieldDBSearch.js
@@ -630,7 +630,7 @@ Core.Agent.DynamicFieldDBSearch = (function(TargetNS) {
         var FieldID = Field;
         var IndexOfActivityDialogID = Field.indexOf('_' + ActivityDialogID);
         if ( ActivityDialogID != '' && IndexOfActivityDialogID > 0 ) {
-            Field = Field.substr(0, IndexOfActivityDialogID);
+            FieldName = Field.substr(0, IndexOfActivityDialogID);
         }
 
         URL = Core.Config.Get('Baselink');


### PR DESCRIPTION
Closing #2887 

Also included a fix for a backend bug I came across: Due to EditFieldValueGet returning `[undef]` even in non-multivalue case, it always overwrites `$Param{Value}` in EditFieldRender, which leads to database fields being empty despite existing values.