### PR TITLE
Issue #2938: Param ConfigItemHandled

### DIFF
--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -131,6 +131,7 @@ sub ValueSet {
 
     return $Kernel::OM->Get('Kernel::System::DynamicField::Backend')->ValueSet(
         %Param,
+        ConfigItemHandled  => 0,
         DynamicFieldConfig => $AttributeDFConfig,
         ObjectID           => $ReferencedObjectID,
     );


### PR DESCRIPTION
Overwrite param ConfigItemHandled to permit execution of PostValueSet code for field which lens points to.

The param ConfigItemHandled, stemming from Kernel/System/ITSMConfigItem/Version.pm, subs VersionAdd and VersionUpdate, is currently passed on to the ValueSet of the field a DF Lens points to, which prevents PostValueSet for this lensed field, e.g. including Cache Cleanup for a referenced configitem.

Referencing #2938