### PR TITLE
Issue #2938: Nested lens fields

### DIFF
--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -120,7 +120,7 @@ sub ValueSet {
     my $ReferencedObjectID = $Self->_GetReferencedObjectID(
         ObjectID               => $Param{ObjectID},
         LensDynamicFieldConfig => $LensDFConfig,
-        EditFieldValue         => 1,
+        EditFieldValue         => $LensDFConfig->{FieldType} eq 'Lens' ? 0 : 1,
     );
 
     return unless $ReferencedObjectID;


### PR DESCRIPTION
Nested lens fields cannot get their object id from EditFieldValueGet.

Because the reference field of a nested lens field does (usually?) not exist on the mask, in this case the object id has to be retrieved from the database.

Referencing #2938