### PR TITLE
Issue #3052: upgrade Locale::CLDR to 0.44.1

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -1037,7 +1037,7 @@ my @NeededModules = (
     {
         Module          => 'Locale::CLDR',
         Features        => ['div:cldr'],
-        VersionRequired => '== 0.40.1',
+        VersionRequired => '== 0.44.1',
         Comment         => 'localisation from the CLDR project',
         InstTypes       => {
             aptget => undef,    # not in any Debian package
@@ -1219,7 +1219,7 @@ for my $Code (qw(Ar De Es Fr Hu Ko Nb Pt Ru Sr Zh)) {
         {
             Module          => "Locale::CLDR::Locales::$Code",
             Features        => ['div:cldr'],
-            VersionRequired => '== 0.40.1',
+            VersionRequired => '== 0.44.1',
             Comment         => 'language packs from the CLDR project',
             InstTypes       => {
                 aptget => undef,    # not in any Debian package

--- a/cpanfile
+++ b/cpanfile
@@ -204,40 +204,40 @@ feature 'div:bcrypt', 'Support for feature div:bcrypt' => sub {
 
 feature 'div:cldr', 'Support for feature div:cldr' => sub {
     # localisation from the CLDR project
-    requires 'Locale::CLDR', '== 0.40.1';
+    requires 'Locale::CLDR', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ar', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ar', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::De', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::De', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Es', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Es', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Fr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Fr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Hu', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Hu', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ko', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ko', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Nb', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Nb', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Pt', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Pt', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ru', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ru', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Sr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Sr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Zh', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Zh', '== 0.44.1';
 
 };
 
@@ -390,7 +390,7 @@ feature 'optional', 'Support for feature optional' => sub {
     requires 'Crypt::Eksblowfish::Bcrypt';
 
     # localisation from the CLDR project
-    requires 'Locale::CLDR', '== 0.40.1';
+    requires 'Locale::CLDR', '== 0.44.1';
 
     # Required for Generic Interface XSLT mapping module.
     requires 'XML::LibXSLT';
@@ -432,37 +432,37 @@ feature 'optional', 'Support for feature optional' => sub {
     requires 'Locale::PO';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ar', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ar', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::De', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::De', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Es', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Es', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Fr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Fr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Hu', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Hu', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ko', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ko', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Nb', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Nb', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Pt', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Pt', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ru', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ru', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Sr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Sr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Zh', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Zh', '== 0.44.1';
 
 };
 

--- a/cpanfile.docker
+++ b/cpanfile.docker
@@ -198,40 +198,40 @@ requires 'Const::Fast';
 
 # feature 'div:cldr', 'Support for feature div:cldr' => sub {
     # localisation from the CLDR project
-    requires 'Locale::CLDR', '== 0.40.1';
+    requires 'Locale::CLDR', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ar', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ar', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::De', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::De', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Es', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Es', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Fr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Fr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Hu', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Hu', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ko', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ko', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Nb', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Nb', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Pt', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Pt', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ru', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Ru', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Sr', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Sr', '== 0.44.1';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Zh', '== 0.40.1';
+    requires 'Locale::CLDR::Locales::Zh', '== 0.44.1';
 
 # };
 


### PR DESCRIPTION
Based on the current version 44 of CLDR.
Patch level 1 because there problems installing the language packs from CPAN. Currently a fixed version is required. This is fine for Docker builds. Native installations should install the fixed version.