### PR TITLE
Issue #3087: do not disconnect in cleanup of Kernel::System::DB

### DIFF
--- a/Kernel/System/CustomerAuth/DB.pm
+++ b/Kernel/System/CustomerAuth/DB.pm
@@ -68,17 +68,12 @@ sub new {
 
     if ( $ConfigObject->Get( 'Customer::AuthModule::DB::DSN' . $Param{Count} ) ) {
         $Self->{DBObject} = Kernel::System::DB->new(
-            DatabaseDSN =>
-                $ConfigObject->Get( 'Customer::AuthModule::DB::DSN' . $Param{Count} ),
-            DatabaseUser =>
-                $ConfigObject->Get( 'Customer::AuthModule::DB::User' . $Param{Count} ),
-            DatabasePw =>
-                $ConfigObject->Get( 'Customer::AuthModule::DB::Password' . $Param{Count} ),
-            Type => $ConfigObject->Get( 'Customer::AuthModule::DB::Type' . $Param{Count} )
-                || '',
-            )
-            || die "Can't connect to "
-            . $ConfigObject->Get( 'Customer::AuthModule::DB::DSN' . $Param{Count} );
+            DatabaseDSN             => $ConfigObject->Get( 'Customer::AuthModule::DB::DSN' . $Param{Count} ),
+            DatabaseUser            => $ConfigObject->Get( 'Customer::AuthModule::DB::User' . $Param{Count} ),
+            DatabasePw              => $ConfigObject->Get( 'Customer::AuthModule::DB::Password' . $Param{Count} ),
+            Type                    => $ConfigObject->Get( 'Customer::AuthModule::DB::Type' . $Param{Count} ) || '',
+            DisconnectOnDestruction => 1,
+        ) || die "Can't connect to " . $ConfigObject->Get( 'Customer::AuthModule::DB::DSN' . $Param{Count} );
 
         # remember that we have the DBObject not from parent call
         $Self->{NotParentDBObject} = 1;

--- a/Kernel/System/CustomerCompany/DB.pm
+++ b/Kernel/System/CustomerCompany/DB.pm
@@ -70,10 +70,11 @@ sub new {
     # create new db connect if DSN is given
     if ( $Self->{CustomerCompanyMap}->{Params}->{DSN} ) {
         $Self->{DBObject} = Kernel::System::DB->new(
-            DatabaseDSN  => $Self->{CustomerCompanyMap}->{Params}->{DSN},
-            DatabaseUser => $Self->{CustomerCompanyMap}->{Params}->{User},
-            DatabasePw   => $Self->{CustomerCompanyMap}->{Params}->{Password},
-            Type         => $Self->{CustomerCompanyMap}->{Params}->{Type} || '',
+            DatabaseDSN             => $Self->{CustomerCompanyMap}->{Params}->{DSN},
+            DatabaseUser            => $Self->{CustomerCompanyMap}->{Params}->{User},
+            DatabasePw              => $Self->{CustomerCompanyMap}->{Params}->{Password},
+            Type                    => $Self->{CustomerCompanyMap}->{Params}->{Type} || '',
+            DisconnectOnDestruction => 1,
         ) || die('Can\'t connect to database!');
 
         # remember that we have the DBObject not from parent call

--- a/Kernel/System/CustomerUser/DB.pm
+++ b/Kernel/System/CustomerUser/DB.pm
@@ -110,6 +110,7 @@ sub new {
             DatabaseUser => $Self->{CustomerUserMap}->{Params}->{User},
             DatabasePw   => $Self->{CustomerUserMap}->{Params}->{Password},
             %{ $Self->{CustomerUserMap}->{Params} },
+            DisconnectOnDestruction => 1,
         ) || die('Can\'t connect to database!');
 
         # remember that we have the DBObject not from parent call

--- a/Kernel/System/DynamicFieldDB.pm
+++ b/Kernel/System/DynamicFieldDB.pm
@@ -109,10 +109,11 @@ sub new {
 
     # get the specific database object
     $Self->{DBObject} = Kernel::System::DB->new(
-        DatabaseDSN  => $DatabaseDSN,
-        DatabaseUser => $Self->{DynamicFieldConfig}->{Config}->{User},
-        DatabasePw   => $Self->{DynamicFieldConfig}->{Config}->{Password},
-        Type         => $DatabaseType,
+        DatabaseDSN             => $DatabaseDSN,
+        DatabaseUser            => $Self->{DynamicFieldConfig}->{Config}->{User},
+        DatabasePw              => $Self->{DynamicFieldConfig}->{Config}->{Password},
+        Type                    => $DatabaseType,
+        DisconnectOnDestruction => 1,
     );
 
     $Self->{LikeEscapeString} = $Self->{DBObject}->GetDatabaseFunction('LikeEscapeString');

--- a/Kernel/System/MigrateFromOTRS/CloneDB/Driver/mysql.pm
+++ b/Kernel/System/MigrateFromOTRS/CloneDB/Driver/mysql.pm
@@ -76,10 +76,11 @@ sub CreateOTRSDBConnection {
 
     # create target DB object
     my $OTRSDBObject = Kernel::System::DB->new(
-        DatabaseDSN  => $Param{OTRSDatabaseDSN},
-        DatabaseUser => $Param{DBUser},
-        DatabasePw   => $Param{DBPassword},
-        Type         => $Param{DBType},
+        DatabaseDSN             => $Param{OTRSDatabaseDSN},
+        DatabaseUser            => $Param{DBUser},
+        DatabasePw              => $Param{DBPassword},
+        Type                    => $Param{DBType},
+        DisconnectOnDestruction => 1,
     );
 
     if ( !$OTRSDBObject ) {

--- a/Kernel/System/MigrateFromOTRS/CloneDB/Driver/oracle.pm
+++ b/Kernel/System/MigrateFromOTRS/CloneDB/Driver/oracle.pm
@@ -73,10 +73,11 @@ sub CreateOTRSDBConnection {
 
     # create target DB object
     my $OTRSDBObject = Kernel::System::DB->new(
-        DatabaseDSN  => $Param{DBDSN},
-        DatabaseUser => $Param{DBUser},
-        DatabasePw   => $Param{DBPassword},
-        Type         => $Param{DBType},
+        DatabaseDSN             => $Param{DBDSN},
+        DatabaseUser            => $Param{DBUser},
+        DatabasePw              => $Param{DBPassword},
+        Type                    => $Param{DBType},
+        DisconnectOnDestruction => 1,
     );
 
     if ( !$OTRSDBObject ) {

--- a/Kernel/System/MigrateFromOTRS/CloneDB/Driver/postgresql.pm
+++ b/Kernel/System/MigrateFromOTRS/CloneDB/Driver/postgresql.pm
@@ -76,10 +76,11 @@ sub CreateOTRSDBConnection {
 
     # create target DB object
     my $OTRSDBObject = Kernel::System::DB->new(
-        DatabaseDSN  => $Param{OTRSDatabaseDSN},
-        DatabaseUser => $Param{DBUser},
-        DatabasePw   => $Param{DBPassword},
-        Type         => $Param{DBType},
+        DatabaseDSN             => $Param{OTRSDatabaseDSN},
+        DatabaseUser            => $Param{DBUser},
+        DatabasePw              => $Param{DBPassword},
+        Type                    => $Param{DBType},
+        DisconnectOnDestruction => 1,
     );
 
     if ( !$OTRSDBObject ) {


### PR DESCRIPTION
This effectively activates DB connections that are persistent over requests. In special cases the old behavior can be restored by passing "DisconnectOnDestruction => 1" to the constructor.