### PR TITLE
Issue #2976: add better synopsis of the ObjectLog() method

### DIFF
--- a/Kernel/System/CommunicationLog.pm
+++ b/Kernel/System/CommunicationLog.pm
@@ -276,13 +276,13 @@ sub ObjectLogStop {
 Adds a log entry for a certain log object.
 
     my $Success = $CommunicationLogObject->ObjectLog(
-        ObjectLogType => '...' # (required) To be defined by the related LogObject
-        ObjectLogID   => 123, # (required) The ObjectID of the started object type
+        ObjectLogType => 'Message', # (required) To be defined by the related LogObject
+        Priority      => 'Error',   # optional, the default is 'Info'
+        Key           => 'Kernel::System::MailQueue',
+        Value         => 'Need Message',
     );
 
-Returns:
-
-    1 in case of success, 0 in case of errors
+Returns 1 in case of success, 0 or undef in case of errors.
 
 =cut
 


### PR DESCRIPTION
The parameter ObjectLogID is not passed, but determined within the method.