### PR TITLE
Issue #3124: Pass object and field type as params in clone url.

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldReference.pm
+++ b/Kernel/Modules/AdminDynamicFieldReference.pm
@@ -221,11 +221,11 @@ sub _Add {
         next SETTING if !$Setting->{InputType};
 
         my $Name = $Setting->{ConfigParamName};
-        if ( $Setting->{Multiple} ) {
+        if ( $Setting->{Multiple} && !defined $GetParam{$Name} ) {
             $GetParam{$Name}->@* = $ParamObject->GetArray( Param => $Name );
         }
         else {
-            $GetParam{$Name} = $ParamObject->GetParam( Param => $Name );
+            $GetParam{$Name} //= $ParamObject->GetParam( Param => $Name );
         }
 
         # validate input if necessary

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicField.tt
@@ -210,7 +210,7 @@
                             </td>
                             <td class="Center">
 [% RenderBlockStart("CloneLink") %]
-                                <a class="DynamicFieldClone" href="[% Env("Baselink") %]Action=[% Data.ConfigDialog %];Subaction=Add;ID=[% Data.ID | uri %][% Data.FilterStrg %]" title="[% Translate("Clone from this field") | html %]">
+                                <a class="DynamicFieldClone" href="[% Env("Baselink") %]Action=[% Data.ConfigDialog %];Subaction=Add;ID=[% Data.ID | uri %][% Data.FilterStrg %];FieldType=[% Data.FieldTypeName | uri %];ObjectType=[% Data.ObjectTypeName | uri %]" title="[% Translate("Clone from this field") | html %]">
                                     <i class="fa fa-copy"></i>
                                 </a>
 [% RenderBlockEnd("CloneLink") %]


### PR DESCRIPTION
Prevent overwriting field type setting configs with undef / empty.

Closing #3124