### PR TITLE
Issue #3213: switch to tj-actions/changed-files@v43

### DIFF
--- a/.github/workflows/code_policy.yml
+++ b/.github/workflows/code_policy.yml
@@ -11,8 +11,10 @@ jobs:
         env:
             PERL5LIB: local/lib/perl5
         steps:
-            - id: files
-              uses: jitterbit/get-changed-files@v1
+
+            # list of added or changed files will be used in the 'compile-checcompile-check' step
+            - id: changed-files
+              uses: tj-actions/changed-files@v43
 
             - name: 'install dependencies'
               run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install libxml2-utils libxslt-dev graphviz libqrencode-dev odbcinst1debian2 libodbc1 odbcinst unixodbc-dev unixodbc
@@ -76,12 +78,12 @@ jobs:
 
             # The actual test steps. Check syntax and the CodePolicy.
 
-            # There are situations where there are no added or modidied files. But with an empty
+            # There are situations where there are no added or changed files. But with an empty
             # argument list all files would be checked, which can easily lead to errors with missing dependencies.
             # Therefore make sure that at least one argument is passed.
             # :: tells prove that whatever follows should be passed to the test script
-            - name: prove
-              run: 'prove -I . -I Kernel/cpan-lib -I Custom --verbose scripts/test/Compile.t :: Kernel/Config.pm ${{ steps.files.outputs.added_modified }}'
+            - name: compile-check
+              run: 'prove -I . -I Kernel/cpan-lib -I Custom --verbose scripts/test/Compile.t :: Kernel/Config.pm ${{ steps.files.outputs.all_changed_files }}'
 
             - name: 'checkout codepolicy'
               uses: actions/checkout@v2
@@ -91,4 +93,4 @@ jobs:
                 path: codepolicy
 
             - name: 'run CodePolicy'
-              run: codepolicy/bin/otobo.CodePolicy.pl -l ${{ steps.files.outputs.added_modified }}
+              run: codepolicy/bin/otobo.CodePolicy.pl -l ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
for getting the list of changed files. This action seems to be better maintained than jitterbit/get-changed-files@v1.