### PR TITLE
Issue #3213: use the Github action actions/checkout@v4

### DIFF
--- a/.github/workflows/cache_local_lib.yml
+++ b/.github/workflows/cache_local_lib.yml
@@ -50,9 +50,9 @@ jobs:
                 path: local
                 key: ${{ runner.os }}-${{steps.get-sha.outputs.result}}-local_lib-20240320a
 
-            - name: 'checkout otobo'
+            - name: 'check out OTOBO'
               if: steps.cache_local_lib.outputs.cache-hit != 'true'
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: 'Get SHA of cpanfile.docker for doublechecking'
               id: get-sha-doublecheck

--- a/.github/workflows/code_policy.yml
+++ b/.github/workflows/code_policy.yml
@@ -18,8 +18,9 @@ jobs:
 
             - name: 'install dependencies'
               run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install libxml2-utils libxslt-dev graphviz libqrencode-dev odbcinst1debian2 libodbc1 odbcinst unixodbc-dev unixodbc
-            - name: 'checkout otobo'
-              uses: actions/checkout@v2
+
+            - name: 'check out OTOBO'
+              uses: actions/checkout@v4
 
             # some diagnostics
             - name: diagnostics
@@ -85,8 +86,8 @@ jobs:
             - name: compile-check
               run: 'prove -I . -I Kernel/cpan-lib -I Custom --verbose scripts/test/Compile.t :: Kernel/Config.pm ${{ steps.files.outputs.all_changed_files }}'
 
-            - name: 'checkout codepolicy'
-              uses: actions/checkout@v2
+            - name: 'checkout CodePolicy'
+              uses: actions/checkout@v4
               with:
                 repository: RotherOSS/codepolicy
                 ref: rel-11_0


### PR DESCRIPTION
This change should avoid warnings about using
a deprecated version of node.