### PR TITLE
Issue #3213: upgrade to Github action actions/github-script@v7

### DIFF
--- a/.github/workflows/cache_local_lib.yml
+++ b/.github/workflows/cache_local_lib.yml
@@ -26,7 +26,7 @@ jobs:
             # See https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 
             - name: Get SHA via the Github REST interface
-              uses: actions/github-script@v4
+              uses: actions/github-script@v7
               id: get-sha
               with:
                 script: |


### PR DESCRIPTION
This should eliminate the warning about node 16.