### PR TITLE
Issue #2711: set init attribute to 'Application'

### DIFF
--- a/Kernel/Config/Files/XML/ImportExport.xml
+++ b/Kernel/Config/Files/XML/ImportExport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<otobo_config version="2.0" init="Framework">
+<otobo_config version="2.0" init="Application">
 
     <Setting Name="Frontend::Module###AdminImportExport" Required="0" Valid="1">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>


### PR DESCRIPTION
now Framework.xml is the only file in Kernel/Config/Files/XML that has 'Framework' as its init attribute. This is more intuitive.