### PR TITLE
Issue #3157: set the init attribute to 'Application'

### DIFF
--- a/Kernel/Config/Files/XML/ArticleFeatures.xml
+++ b/Kernel/Config/Files/XML/ArticleFeatures.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<otobo_config version="2.0" init="Changes">
+<otobo_config version="2.0" init="Application">
     <Setting Name="Ticket::Frontend::Article::Actions###Internal" Required="1" Valid="1">
         <Description Translatable="1">Defines available article actions for Internal articles.</Description>
         <Navigation>Frontend::Agent::View::TicketZoom::ArticleAction</Navigation>
@@ -584,4 +584,4 @@
             </Hash>
         </Value>
     </Setting>
-</otobo_config>    
+</otobo_config>


### PR DESCRIPTION
This means that in a fresh installation there an no files in Kernel/Config/Files/XML that have the init Attribute 'Changes'. The init attribute 'Changes' is reserved for installation specific overrides.