### PR TITLE
Issue #3136: Switched parameter text from 'ChildID' to name of dynamic field.

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
@@ -218,7 +218,7 @@ sub Params {
         },
         {
             Key      => 'StoreTicketIDDynamicField',
-            Value    => 'ChildID (name of DynamicField holding the id of the created ticket in the original ticket)',
+            Value    => 'NameX (name of DynamicField holding the id of the created ticket in the original ticket)',
             Optional => 1,
         },
     );


### PR DESCRIPTION
Referencing #3136