### PR TITLE
Issue #3318: Added catch block to print error in case of invalid Autoload file.

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -2401,7 +2401,10 @@ sub AutoloadPerlPackages {
                 my $FileName = $Package =~ s{::}{/}smxgr;
 
                 require $FileName . '.pm'; ## nofilter(TidyAll::Plugin::OTOBO::Perl::Require)
-            };
+            }
+            catch {
+                print STDERR "ERROR: $_!\n";
+            }
         }
     }
 


### PR DESCRIPTION
Error handling derived from comparable occasions within the same file.

Closing #3318