### PR TITLE
Issue #3342: [high contrast skin] Admin overview icon color

### DIFF
--- a/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.PageLayout.css
+++ b/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.PageLayout.css
@@ -57,4 +57,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     color: var(--colTextLight);
 }
 
+.ItemListGrid.WithIcons > li span.Icons i {
+    color: var(--colTextDark);
+}
+
 } /* end @media */


### PR DESCRIPTION
Copied css setting for admin overview icons and changed icon color from light to dark.

Edit: Also affects icons in AgentPreferences.

Referencing #3342