### PR TITLE
Issue #3342: [high contrast skin] Setting update box overlaps border

### DIFF
--- a/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Admin.SystemConfiguration.css
+++ b/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Admin.SystemConfiguration.css
@@ -118,4 +118,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     background: var(--colBGDark);
 }
 
+.WidgetSimple.Setting .Content .SettingUpdateBox {
+    background-color: unset;
+}
+
 } /* end @media */

--- a/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Admin.SystemConfiguration.css
+++ b/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Admin.SystemConfiguration.css
@@ -119,7 +119,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 .WidgetSimple.Setting .Content .SettingUpdateBox {
-    background-color: unset;
+    background: unset;
 }
 
 } /* end @media */

--- a/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Preferences.css
+++ b/var/httpd/htdocs/skins/Agent/highcontrast/css/Core.Agent.Preferences.css
@@ -25,7 +25,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
  * @subsubsection     General
  */
 .Preferences .WidgetSimple.Setting.IsLockedByMe .Content .SettingUpdateBox {
-    background: var(--colBGElement);
+    background: unset;
 }
 
 .Preferences .WidgetSimple.Setting.IsLockedByMe {


### PR DESCRIPTION
Unset background color of SettingUpdateBox in AgentPreferences and AdminSystemConfiguration to prevent overlapping with border.

Referencing #3342