### PR TITLE
Issue #2142: Removed special css rule for textarea in process module.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketProcess.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketProcess.css
@@ -157,11 +157,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     text-align: center;
 }
 
-textarea {
-    font-family: Quicksand, "Helvetica Neue",Helvetica,Arial,sans-serif;
-    padding: 5px;
-}
-
 .FieldHelpContainer {
     position: relative;
 }


### PR DESCRIPTION
As this has been mentioned again, I'll decided to provide a PR for it. Besides AgentTicketProcess, the css file is included in AgentTicketZoom and AgentTicketArticleVersionView, both of which do not use textareas as far as I see. So, this really only affects AgentTicketProcess, and I can see the advantage of being consistent with other masks.

Closing #2142