### PR TITLE
Issue #3374: Use hardcoded colors as fallback if sysconfig colors are not present.

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -313,6 +313,31 @@ sub LoadDefaults {
     # (URL CSS path.)
     $Self->{'Frontend::CSSPath'} = '<OTOBO_CONFIG_Frontend::WebPath>css/';
 
+    # AgentColorDefinitions
+    $Self->{'AgentColorDefinitions'} = {
+        MainDark      => '#00023c',
+        MainLight     => '#000099',
+        MainHover     => '#001bff',
+        BGElement     => '#fff',
+        BGLight       => '#f7f7f9',
+        BGLightMedium => '#eeeef2',
+        BGMedium      => '#e5e5eb',
+        BGMediumDark  => '#cdcdd8',
+        BGDark        => '#bfc0ce',
+        TextLight     => '#7f809d',
+        TextMedium    => '#54557c',
+        TextDark      => '#00023c',
+        TextErr       => '#ea2400',
+        TextWarn      => '#f5af36',
+        Highlight     => '#fef235',
+        NotifyOK      => '#c4cdfa',
+        NotifyWarn    => '#fffccc',
+        NotifyErr     => '#f9bcb2',
+        HoverLight    => '#fffccc',
+        HoverDark     => '#fef235',
+        ShadowDark    => 'rgba(0,2,71,0.16)',
+    };
+
     # Frontend::ImagePath
     # (URL image path of icons for navigation.)
     $Self->{'Frontend::ImagePath'} = '<OTOBO_CONFIG_Frontend::WebPath>skins/Agent/default/img/';

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1649,32 +1649,12 @@ sub Header {
     # Load colors based on Skin selection
     $Self->{SkinSelected} ||= 'default';
 
-    my $ColorDefinitions
-        = $Self->{SkinSelected} eq 'default' ? $ConfigObject->Get("AgentColorDefinitions") : $ConfigObject->Get("SkinColorDefinition::$Self->{SkinSelected}");
-
-    if ( !IsHashRefWithData($ColorDefinitions) ) {
-        $ColorDefinitions = {
-            MainDark      => '#00023c',
-            MainLight     => '#000099',
-            MainHover     => '#001bff',
-            BGElement     => '#fff',
-            BGLight       => '#f7f7f9',
-            BGLightMedium => '#eeeef2',
-            BGMedium      => '#e5e5eb',
-            BGMediumDark  => '#cdcdd8',
-            BGDark        => '#bfc0ce',
-            TextLight     => '#7f809d',
-            TextMedium    => '#54557c',
-            TextDark      => '#00023c',
-            TextErr       => '#ea2400',
-            Highlight     => '#fef235',
-            NotifyOK      => '#c4cdfa',
-            NotifyWarn    => '#fffccc',
-            NotifyErr     => '#f9bcb2',
-            HoverLight    => '#fffccc',
-            HoverDark     => '#fef235',
-            ShadowDark    => 'rgba(0,2,71,0.16)',
-        };
+    my $ColorDefinitions;
+    if ( $Self->{SkinSelected} // $Self->{SkinSelected} ne 'default' ) {
+        $ColorDefinitions = $ConfigObject->Get("SkinColorDefinition::$Self->{SkinSelected}") // $ConfigObject->Get('AgentColorDefinitions');
+    }
+    else {
+        $ColorDefinitions = $ConfigObject->Get('AgentColorDefinitions');
     }
 
     for my $Color ( sort keys %{$ColorDefinitions} ) {

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1650,7 +1650,7 @@ sub Header {
     $Self->{SkinSelected} ||= 'default';
 
     my $ColorDefinitions;
-    if ( $Self->{SkinSelected} // $Self->{SkinSelected} ne 'default' ) {
+    if ( $Self->{SkinSelected} && $Self->{SkinSelected} ne 'default' ) {
         $ColorDefinitions = $ConfigObject->Get("SkinColorDefinition::$Self->{SkinSelected}") // $ConfigObject->Get('AgentColorDefinitions');
     }
     else {
@@ -4444,8 +4444,13 @@ sub CustomerHeader {
     # Load colors based on Skin selection
     # define color scheme
     $Self->{UserSkin} ||= 'default';
-    my $ColorDefinitions
-        = $Self->{UserSkin} eq 'default' ? $ConfigObject->Get('CustomerColorDefinitions') : $ConfigObject->Get("CustomerSkinColorDefinition::$Self->{UserSkin}");
+    my $ColorDefinitions;
+    if ( $Self->{UserSkin} && $Self->{UserSkin} ne 'default' ) {
+        $ColorDefinitions = $ConfigObject->Get("CustomerSkinColorDefinition::$Self->{UserSkin}") // $ConfigObject->Get('CustomerColorDefinitions');
+    }
+    else {
+        $ColorDefinitions = $ConfigObject->Get('CustomerColorDefinitions');
+    }
 
     for my $Color ( sort keys %{$ColorDefinitions} ) {
         $Param{ColorDefinitions} .= "--col$Color:$ColorDefinitions->{ $Color };";

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1649,7 +1649,33 @@ sub Header {
     # Load colors based on Skin selection
     $Self->{SkinSelected} ||= 'default';
 
-    my $ColorDefinitions = $Self->{SkinSelected} eq 'default' ?  $ConfigObject->Get("AgentColorDefinitions") : $ConfigObject->Get("SkinColorDefinition::$Self->{SkinSelected}");
+    my $ColorDefinitions
+        = $Self->{SkinSelected} eq 'default' ? $ConfigObject->Get("AgentColorDefinitions") : $ConfigObject->Get("SkinColorDefinition::$Self->{SkinSelected}");
+
+    if ( !IsHashRefWithData($ColorDefinitions) ) {
+        $ColorDefinitions = {
+            MainDark      => '#00023c',
+            MainLight     => '#000099',
+            MainHover     => '#001bff',
+            BGElement     => '#fff',
+            BGLight       => '#f7f7f9',
+            BGLightMedium => '#eeeef2',
+            BGMedium      => '#e5e5eb',
+            BGMediumDark  => '#cdcdd8',
+            BGDark        => '#bfc0ce',
+            TextLight     => '#7f809d',
+            TextMedium    => '#54557c',
+            TextDark      => '#00023c',
+            TextErr       => '#ea2400',
+            Highlight     => '#fef235',
+            NotifyOK      => '#c4cdfa',
+            NotifyWarn    => '#fffccc',
+            NotifyErr     => '#f9bcb2',
+            HoverLight    => '#fffccc',
+            HoverDark     => '#fef235',
+            ShadowDark    => 'rgba(0,2,71,0.16)',
+        };
+    }
 
     for my $Color ( sort keys %{$ColorDefinitions} ) {
         $Param{ColorDefinitions} .= "--col$Color:$ColorDefinitions->{ $Color };";
@@ -4435,10 +4461,11 @@ sub CustomerHeader {
     # and the tags referencing them (see LayoutLoader)
     $Self->LoaderCreateCustomerCSSCalls();
 
-    # Load colors based on Skin selection   
+    # Load colors based on Skin selection
     # define color scheme
     $Self->{UserSkin} ||= 'default';
-    my $ColorDefinitions = $Self->{UserSkin} eq 'default' ? $ConfigObject->Get('CustomerColorDefinitions') : $ConfigObject->Get("CustomerSkinColorDefinition::$Self->{UserSkin}");
+    my $ColorDefinitions
+        = $Self->{UserSkin} eq 'default' ? $ConfigObject->Get('CustomerColorDefinitions') : $ConfigObject->Get("CustomerSkinColorDefinition::$Self->{UserSkin}");
 
     for my $Color ( sort keys %{$ColorDefinitions} ) {
         $Param{ColorDefinitions} .= "--col$Color:$ColorDefinitions->{ $Color };";


### PR DESCRIPTION
Note: Does not apply to login and is intended for installer.

Closing #3374