### PR TITLE
Issue #3326: avoid assignment to the topic by diamond operator

### DIFF
--- a/Kernel/Modules/AgentTicketAttachment.pm
+++ b/Kernel/Modules/AgentTicketAttachment.pm
@@ -177,8 +177,8 @@ sub Run {
         # TODO: use Capture::Tiny
         my $GeneratedHTML = '';
         if ( open my $ViewerFH, '-|', "$Viewer $FilenameContent" ) {    ## no critic qw(OTOBO::ProhibitOpen)
-            while (<$ViewerFH>) {
-                $GeneratedHTML .= $_;
+            while ( my $s = <$ViewerFH> ) {
+                $GeneratedHTML .= $s;
             }
             close $ViewerFH;
         }

--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -1102,14 +1102,14 @@ sub ReConfigure {
     open( my $In, '<', $ConfigFile )                                                ## no critic qw(InputOutput::RequireBriefOpen OTOBO::ProhibitOpen)
         or $LayoutObject->FatalError( Message => "Can't open $ConfigFile: $!" );    ## no critic qw(OTOBO::ProhibitLowPrecedenceOps)
     my $Config = '';
-    while (<$In>) {
+    while ( my $s = <$In> ) {
 
-        # Skip empty lines or comments.
-        if ( !$_ || $_ =~ /^\s*#/ || $_ =~ /^\s*$/ ) {
-            $Config .= $_;
+        # no need to adapt empty lines or comments.
+        if ( !$s || $s =~ /^\s*#/ || $s =~ /^\s*$/ ) {
+            $Config .= $s;
         }
         else {
-            my $NewConfig = $_;
+            my $NewConfig = $s;
 
             # Replace config with %Param.
             for my $Key ( sort keys %Param ) {
@@ -1117,12 +1117,10 @@ sub ReConfigure {
                 # Database passwords can contain characters like '@' or '$' and should be single-quoted
                 #   same goes for database hosts which can be like 'myserver\instance name' for MS SQL.
                 if ( $Key eq 'DatabasePw' || $Key eq 'DatabaseHost' ) {
-                    $NewConfig =~
-                        s/(\$Self->\{("|'|)$Key("|'|)} =.+?('|"));/\$Self->{'$Key'} = '$Param{$Key}';/g;
+                    $NewConfig =~ s/(\$Self->\{("|'|)$Key("|'|)} =.+?('|"));/\$Self->{'$Key'} = '$Param{$Key}';/g;
                 }
                 else {
-                    $NewConfig =~
-                        s/(\$Self->\{("|'|)$Key("|'|)} =.+?('|"));/\$Self->{'$Key'} = "$Param{$Key}";/g;
+                    $NewConfig =~ s/(\$Self->\{("|'|)$Key("|'|)} =.+?('|"));/\$Self->{'$Key'} = "$Param{$Key}";/g;
                 }
             }
             $Config .= $NewConfig;

--- a/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/TranslationsUpdate.pm
@@ -988,6 +988,8 @@ EOF
     else {
 
         open( my $In, '<', $Param{LanguageFile} ) || die "Can't open: $Param{LanguageFile}\n";    ## no critic qw(InputOutput::RequireBriefOpen OTOBO::ProhibitOpen)
+        ## no critic qw(Community::WhileDiamondDefaultAssignment)
+        # TODO: it is not obvious why both $Line and $_ are used in this block
         while (<$In>) {
             my $Line = $_;
             $Kernel::OM->Get('Kernel::System::Encode')->EncodeInput( \$Line );

--- a/Kernel/System/SupportDataCollector/Plugin/OS/Swap.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OS/Swap.pm
@@ -40,8 +40,7 @@ sub Run {
 
     # If used OS is a linux system
     if ( -e "/proc/meminfo" && open( $MemInfoFile, '<', "/proc/meminfo" ) ) {    ## no critic qw(InputOutput::RequireBriefOpen OTOBO::ProhibitOpen)
-        while (<$MemInfoFile>) {
-            my $TmpLine = $_;
+        while ( my $TmpLine = <$MemInfoFile> ) {
             if ( $TmpLine =~ m/MemTotal/ ) {
                 $TmpLine =~ s/^.*?(\d+).*$/$1/;
                 $MemTotal = int($TmpLine);

--- a/bin/otobo.CheckSum.pl
+++ b/bin/otobo.CheckSum.pl
@@ -82,8 +82,8 @@ if ( $Action eq 'create' ) {
 }
 else {
     open( my $In, '<', $Archive ) || die "ERROR: Can't read: $Archive";      ## no critic qw(OTOBO::ProhibitOpen)
-    while (<$In>) {
-        my @Row = split /::/, $_;
+    while ( my $s = <$In> ) {
+        my @Row = split /::/, $s;
         chomp $Row[1];
         $Compare{ $Row[1] } = $Row[0];
     }

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -207,7 +207,7 @@ else {
     for my $Cmd (@Cmds) {
         my $IsInstalled = 0;
         open my $In, '-|', "which $Cmd";    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireBriefOpen)
-        while (<$In>) {
+        while ( my $s = <$In> ) {
             $IsInstalled = 1;
         }
         if ( !$IsInstalled ) {

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -88,7 +88,7 @@ else {
 for my $CMD ( 'cp', 'tar', $DecompressCMD ) {
     my $IsInstalled = 0;
     open( my $Input, '-|', "which $CMD" );    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireBriefOpen)
-    while (<$Input>) {
+    while ( my $s = <$Input> ) {
         $IsInstalled = 1;
     }
     if ( !$IsInstalled ) {
@@ -140,7 +140,7 @@ if ( $DatabaseDSN =~ m/:mysql/i ) {
 
     my $IsInstalled = 0;
     open( my $Input, '-|', "which $DBDump" );    ## no critic qw(OTOBO::ProhibitOpen InputOutput::RequireBriefOpen)
-    while (<$Input>) {
+    while ( my $s = <$Input> ) {
         $IsInstalled = 1;
     }
     if ( !$IsInstalled ) {
@@ -158,7 +158,7 @@ elsif ( $DatabaseDSN =~ m/:pg/i ) {
 
     my $IsInstalled = 0;
     open( my $Input, '-|', "which $DBDump" );    ## no critic qw(OTOBO::ProhibitOpen)
-    while (<$Input>) {
+    while ( my $s = <$Input> ) {
         $IsInstalled = 1;
     }
     close $Input;

--- a/scripts/test/EmailParser.t
+++ b/scripts/test/EmailParser.t
@@ -35,12 +35,9 @@ my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test #1
-my @Array = ();
-open( my $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test1.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+open( my $IN, '<', "$Home/scripts/test/sample/EmailParser/PostMaster-Test1.box" );    ## no critic qw(OTOBO::ProhibitOpen)
+my @Array = <$IN>;
+close $IN;
 
 # create local object
 my $EmailParserObject = Kernel::System::EmailParser->new(
@@ -130,10 +127,8 @@ $Self->Is(
 # test #3
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test3.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -159,9 +154,7 @@ $Self->Is(
 # test #4
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test4.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
+@Array = <$IN>;
 close($IN);
 
 $EmailParserObject = Kernel::System::EmailParser->new(
@@ -228,10 +221,8 @@ for my $Key ( sort keys %MatchNot ) {
 # test #5
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test5.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -284,10 +275,8 @@ $Self->Is(
 # test #6
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test6.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -337,10 +326,8 @@ $Self->Is(
 # test #7
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test7.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -388,10 +375,8 @@ $Self->Is(
 # test #8
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test8.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -420,10 +405,8 @@ $Self->True(
 # test #9
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test9.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -456,10 +439,8 @@ $Self->True(
 # test #10
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test10.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -508,10 +489,8 @@ $Self->True(
 # test #11
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test11.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -538,10 +517,8 @@ $Self->True(
 # test #12
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test12.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -642,10 +619,8 @@ $Self->True(
 # test #13
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test13.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -670,10 +645,8 @@ $Self->Is(
 # test #14
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test14.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -703,10 +676,8 @@ $Self->Is(
 # test #15
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test16.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -803,10 +774,8 @@ for my $Test (@Tests) {
 # test #17
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test19.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -831,10 +800,8 @@ $Self->Is(
 # test #20
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test20.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -858,10 +825,8 @@ $Self->Is(
 # test #21
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test21.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -881,10 +846,8 @@ $Self->Is(
 # test #22
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/PostMaster-Test22.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -904,10 +867,8 @@ $Self->Is(
 # test #23
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/UTF-7.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -922,10 +883,8 @@ $Self->Is(
 # test #24
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/UTF-7.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 $EmailParserObject = Kernel::System::EmailParser->new(
     Email => \@Array,
@@ -940,10 +899,8 @@ $Self->Is(
 # test #25 (bug #12108)
 @Array = ();
 open( $IN, "<", "$Home/scripts/test/sample/EmailParser/UTF-7.box" );    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push( @Array, $_ );
-}
-close($IN);
+@Array = <$IN>;
+close $IN;
 
 my $Parser = MIME::Parser->new();
 

--- a/scripts/test/EmailParser/BrokenEncoding.t
+++ b/scripts/test/EmailParser/BrokenEncoding.t
@@ -34,11 +34,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#1970
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/BrokenEncoding.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/Bug10395.t
+++ b/scripts/test/EmailParser/Bug10395.t
@@ -33,11 +33,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#1970
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/Bug10395.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/DuplicatedContentTypeHeader.t
+++ b/scripts/test/EmailParser/DuplicatedContentTypeHeader.t
@@ -31,11 +31,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#9989
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/DuplicatedContentTypeHeader.eml";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/EmptyEmail.t
+++ b/scripts/test/EmailParser/EmptyEmail.t
@@ -31,11 +31,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#9989
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/EmptyEmail.eml";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/FilenameWithCRLF.t
+++ b/scripts/test/EmailParser/FilenameWithCRLF.t
@@ -34,11 +34,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#13554
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/FilenameWithCRLF.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/FilenameWithNewline.t
+++ b/scripts/test/EmailParser/FilenameWithNewline.t
@@ -34,11 +34,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#1970
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/FilenameWithNewline.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/NestedMessage.t
+++ b/scripts/test/EmailParser/NestedMessage.t
@@ -31,11 +31,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#1970
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/NestedMessage-Test1.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/UTF8Filename.t
+++ b/scripts/test/EmailParser/UTF8Filename.t
@@ -31,11 +31,8 @@ our $Self;
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#9989
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/UTF8Filename.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/EmailParser/Win7SnippingTool.t
+++ b/scripts/test/EmailParser/Win7SnippingTool.t
@@ -40,11 +40,8 @@ See also: http://bugs.otrs.org/show_bug.cgi?id=8092
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # test for bug#1970
-my @Array;
 open my $IN, '<', "$Home/scripts/test/sample/EmailParser/Win7SnippingTool.box";    ## no critic qw(OTOBO::ProhibitOpen)
-while (<$IN>) {
-    push @Array, $_;
-}
+my @Array = <$IN>;
 close $IN;
 
 # create local object

--- a/scripts/test/XML.t
+++ b/scripts/test/XML.t
@@ -1106,10 +1106,10 @@ $Path .= "/scripts/test/sample/XML/";
 my $File = 'XML-Test-file.xml';
 $String = '';
 if ( open( my $DATA, "<", "$Path/$File" ) ) {    ## no critic qw(OTOBO::ProhibitOpen)
-    while (<$DATA>) {
-        $String .= $_;
+    while ( my $s = <$DATA> ) {
+        $String .= $s;
     }
-    close($DATA);
+    close $DATA;
 
     # charset test - use file from the filesystem and parse it
     @XMLHash = $XMLObject->XMLParse2XMLHash( String => $String );


### PR DESCRIPTION
In specific context, primarily in while conditions, the diamond operator makes an assignment to the topic variable $_. Using this feature is not wrong. However it is not good practice. $_ is a global variable and messing with globals could lead to unwanted side effects.

Therefore honor the Perl::Critic policy Community::WhileDiamondDefaultAssignment The approach is to make simple changes achieving the goal. There is no migration to file slurping or Capture::Tiny.