### PR TITLE
Issue #3413: remove Kernel/cpan-lib in copy_otobo_next

### DIFF
--- a/bin/docker/entrypoint.sh
+++ b/bin/docker/entrypoint.sh
@@ -124,6 +124,23 @@ function exec_web() {
 # preserve added files in the previous
 function copy_otobo_next() {
 
+    # The directory Kernel/cpan-lib is a special case. Perl modules
+    # from previous OTOBO versions should not override the modules
+    # that are provided in /opt/otobo_install/local. So we remove
+    # the entire directory. Potential changes in Kernel/cpan-lib,
+    # that stem from the previous installation, can be recovered from
+    # the backup done with scripts/backup.pl
+    cpan_lib_dir="$OTOBO_HOME/Kernel/cpan-lib"
+    if [ -d  "$OTOBO_HOME/Kernel/cpan-lib" ]; then
+        rm -r $cpan_lib_dir
+        {
+            date
+            echo "Removed the directory $cpan_lib_dir"
+            echo
+        } >> $update_log
+    fi
+
+
     # Copy files recursively.
     # Changed files are overwritten, new files are not deleted.
     # File attributes are preserved.


### PR DESCRIPTION
so that no old versions of Perl modules will linger around