### PR TITLE
Issue #3424: Fixed ShowDeletedArticles parameter bug in article backe…

### DIFF
--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -1227,7 +1227,7 @@ sub _MetaArticleList {
             SQL => "
                     SELECT av.id, av.ticket_id, av.communication_channel_id, av.article_sender_type_id, av.is_visible_for_customer,
                     av.create_by, av.create_time, av.change_by, av.change_time, av.article_delete
-                    FROM article_version av WHERE av.ticket_id = ? AND av.article_delete <> 1 ",
+                    FROM article_version av WHERE av.ticket_id = ? AND av.article_delete <> 1 ORDER BY av.id ASC ",
             Bind => [ \$Param{TicketID} ],
         );
     }

--- a/Kernel/System/Ticket/Article/Backend/Base.pm
+++ b/Kernel/System/Ticket/Article/Backend/Base.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -210,12 +210,14 @@ sub ArticleUpdate {
 Returns article data. Override this method in your class.
 
     my %Article = $ArticleBackendObject->ArticleGet(
-        TicketID      => 123,
-        ArticleID     => 123,
-        DynamicFields => 1,
+        ArticleID           => 42,      # (required)
+        TicketID            => 23,      # (required)
+        DynamicFields       => 1,       # (optional) To include the dynamic field values for this article on the return structure.
+        ShowDeletedArticles => 1,       # (optional) To get deleted articles.
+        VersionView         => 1,       # (optional) To get edited version info.
 
         # Backend specific parameters:
-        # RealNames => 1,
+        RealNames           => 1,       # (optional) To include the From/To/Cc/Bcc fields with real names.
     );
 
 =cut
@@ -509,10 +511,10 @@ sub _MetaArticleUpdate {
 Get article meta data.
 
     my %Article = $Self->_MetaArticleGet(
-        ArticleID => 42,
-        TicketID  => 23,
-        ShowDeletedArticles => 1, # (optional) To get deleted articles.
-        VersionView   => 1,       # (optional) To get edited version info.
+        ArticleID           => 42,      # (required)
+        TicketID            => 23,      # (required)
+        ShowDeletedArticles => 1,       # (optional) To get deleted articles.
+        VersionView         => 1,       # (optional) To get edited version info.
     );
 
 Returns:

--- a/Kernel/System/Ticket/Article/Backend/Chat.pm
+++ b/Kernel/System/Ticket/Article/Backend/Chat.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -292,9 +292,11 @@ sub ArticleCreate {
 Returns single article data.
 
     my %Article = $ArticleBackendObject->ArticleGet(
-        TicketID      => 123,   # (required)
-        ArticleID     => 123,   # (required)
-        DynamicFields => 1,     # (optional) To include the dynamic field values for this article on the return structure.
+        ArticleID           => 42,      # (required)
+        TicketID            => 23,      # (required)
+        DynamicFields       => 1,       # (optional) To include the dynamic field values for this article on the return structure.
+        ShowDeletedArticles => 1,       # (optional) To get deleted articles.
+        VersionView         => 1,       # (optional) To get edited version info.
     );
 
 Returns:

--- a/Kernel/System/Ticket/Article/Backend/Invalid.pm
+++ b/Kernel/System/Ticket/Article/Backend/Invalid.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -78,9 +78,10 @@ sub ArticleUpdate {
 Returns article meta data as also returned by L<Kernel::System::Ticket::Article::ArticleList()>.
 
     my %Article = $ArticleBackendObject->ArticleGet(
-        TicketID      => 123,
-        ArticleID     => 123,
-        DynamicFields => 1,
+        ArticleID           => 42,      # (required)
+        TicketID            => 23,      # (required)
+        ShowDeletedArticles => 1,       # (optional) To get deleted articles.
+        VersionView         => 1,       # (optional) To get edited version info.
     );
 
 =cut

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -1133,13 +1133,13 @@ sub ArticleCreate {
 Returns single article data.
 
     my %Article = $ArticleBackendObject->ArticleGet(
-        TicketID      => 123,     # (required)
-        ArticleID     => 123,     # (required)
-        DynamicFields => 1,       # (optional) To include the dynamic field values for this article on the return structure.
-        RealNames     => 1,       # (optional) To include the From/To/Cc/Bcc fields with real names.
-        ShowDeletedArticles => 1, # (optional) To get deleted articles.
-        VersionView    => 1,      # (optional) To get edited version info.
-        ArticleDeleted => 1,      # (optional) To evaluate if article is deleted.
+        TicketID            => 123,     # (required)
+        ArticleID           => 123,     # (required)
+        DynamicFields       => 1,       # (optional) To include the dynamic field values for this article on the return structure.
+        RealNames           => 1,       # (optional) To include the From/To/Cc/Bcc fields with real names.
+        ShowDeletedArticles => 1,       # (optional) To get deleted articles.
+        VersionView         => 1,       # (optional) To get edited version info.
+        ArticleDeleted      => 1,       # (optional) To evaluate if article is deleted.
     );
 
 Returns:
@@ -1198,7 +1198,7 @@ sub ArticleGet {
     my %Article = $Self->_MetaArticleGet(
         ArticleID           => $Param{ArticleID},
         TicketID            => $Param{TicketID},
-        ShowDeletedArticles => 1,
+        ShowDeletedArticles => $Param{ShowDeletedArticles},
         VersionView         => $Param{VersionView}
     );
     return if !%Article;


### PR DESCRIPTION
Closing #3424

The `ORDER BY` clause is a good addition, even if (currently and from my understanding) not mandatorily necessary.

The real bug is in `Kernel/System/Ticket/Article/Backend/MIMEBase.pm`, where the parameter `ShowDeletedArticles` was a hardcoded `1` instead of passing through what it received.