### PR TITLE
Issue #3100: avoid high load when the LCSS is computed

### DIFF
--- a/scripts/test/Selenium/TestingMethods.t
+++ b/scripts/test/Selenium/TestingMethods.t
@@ -22,6 +22,7 @@ use utf8;
 # core modules
 
 # CPAN modules
+use Test::LongString lcss => 0;
 use Test2::V0;
 
 # OTOBO modules


### PR DESCRIPTION
In TestingMethods.t there are tests whether a string is a substring that are expected to fail. These tests do fail indeed. Test::LongString then tries to show the longest common substring, aka LCSS. For some reason the reporting method produces high load and runs for a long time. That looks like a bug in Test::LongString.

So, turn off LCSS reporting in order to avoid the high load.