### PR TITLE
Issue #3461: Updated CheckModules entry of Data::Peek.

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -1121,11 +1121,12 @@ my @NeededModules = (
     # Feature devel:encoding
     {
         Module    => 'Data::Peek',
-        Features  => ['devel:encoding'],
+        Features  => ['devel:encoding', 'devel:test'],
         Comment   => 'for deeply inspecting scalars, especially strings',
         InstTypes => {
-            aptget => undef,
+            aptget => 'libdata-peek-perl',
             emerge => undef,
+            yum    => 'perl-Data-Peek',
             zypper => undef,
             ports  => undef,
         },


### PR DESCRIPTION
Closing #3461

I was not able to get openSUSE, freeBSD and Gentoo up and running to check their package managers for existing Data::Peek packages, so I only added aptget and yum.