### PR TITLE
Issue #3542: use perl:5.40-slim-bookworm as base image

### DIFF
--- a/otobo.web.dockerfile
+++ b/otobo.web.dockerfile
@@ -15,7 +15,7 @@
 # Note that the minor version of Debian may change between builds.
 #
 # The individual build targets may add additional Debian or CPAN packages.
-FROM perl:5.40-bookworm AS base
+FROM perl:5.40-slim-bookworm AS base
 
 # First there is some initial setup that needs to be done by root.
 USER root
@@ -45,6 +45,14 @@ ENV OTOBO_GROUP otobo
 ENV OTOBO_HOME  /opt/otobo
 RUN apt-get update\
  && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install\
+ "build-essential"\
+ "pkg-config"\
+ "libpq-dev"\
+ "libxml2-dev"\
+ "libxslt-dev"\
+ "libexpat-dev"\
+ "default-libmysqlclient-dev"\
+ "gpg"\
  "ack"\
  "cron"\
  "default-mysql-client"\


### PR DESCRIPTION
Add some Debian package that were required by the installed Perl modules. This includes 'build-essential' neeeded for compiling extensions.

The Debian package 'gpg' installs /usr/bin/gpg which is used in Kernel/System/Crypt/PGP.pm This makes two of three PGP related failures succeed.