### PR TITLE
Issue #2027: Added sysconfig option to display dates without localization indicator.

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -626,11 +626,11 @@
             <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
-    <Setting Name="TimeShowAlwaysLocalization" Required="1" Valid="1">
+    <Setting Name="TimeShowLocalization" Required="1" Valid="1">
         <Description Translatable="1">Shows time with localization indicator (01.01.1970 00:01 (Europe/Berlin)), if enabled; or without (01.01.1970 00:01), if not enabled.</Description>
         <Navigation>Core::Time</Navigation>
         <Value>
-            <Item ValueType="Checkbox">0</Item>
+            <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
     <Setting Name="AttachmentDownloadType" Required="1" Valid="1">

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -626,6 +626,13 @@
             <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
+    <Setting Name="TimeShowAlwaysLocalization" Required="1" Valid="1">
+        <Description Translatable="1">Shows time with localization indicator (01.01.1970 00:01 (Europe/Berlin)), if enabled; or without (01.01.1970 00:01), if not enabled.</Description>
+        <Navigation>Core::Time</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="AttachmentDownloadType" Required="1" Valid="1">
         <Description Translatable="1">Allows choosing between showing the attachments of a ticket in the browser (inline) or just make them downloadable (attachment).</Description>
         <Navigation>Frontend::Base</Navigation>

--- a/Kernel/Language.pm
+++ b/Kernel/Language.pm
@@ -94,6 +94,9 @@ sub new {
     # take time zone
     $Self->{TimeZone} = $Param{UserTimeZone} || $Param{TimeZone} || OTOBOTimeZoneGet();
 
+    # fetch localization setting
+    $Self->{TimeShowLocalization} = $ConfigObject->Get('TimeShowLocalization') || 0;
+
     # Debug
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
@@ -369,7 +372,7 @@ sub FormatTimeString {
 
         # output time zone only if it differs from OTOBO' time zone
         if (
-            $Kernel::OM->Get('Kernel::Config')->Get('TimeShowAlwaysLocalization')
+            $Self->{'TimeShowLocalization'}
             && $Config ne 'DateFormatShort'
             && $Self->{TimeZone}
             && $Self->{TimeZone} ne OTOBOTimeZoneGet()

--- a/Kernel/Language.pm
+++ b/Kernel/Language.pm
@@ -369,7 +369,8 @@ sub FormatTimeString {
 
         # output time zone only if it differs from OTOBO' time zone
         if (
-            $Config ne 'DateFormatShort'
+            $Kernel::OM->Get('Kernel::Config')->Get('TimeShowAlwaysLocalization')
+            && $Config ne 'DateFormatShort'
             && $Self->{TimeZone}
             && $Self->{TimeZone} ne OTOBOTimeZoneGet()
             )


### PR DESCRIPTION
IMPORTANT: Note that this change is in a place where it will take effect **everywhere** - from Ticket lists, Ticket Zoom views, installed packages, created PDFs to sent emails. 

Closing #2027