### PR TITLE
Efflux: Disable logging of plaintext passwords in debugging mode (CVE-2024-43444)

### DIFF
--- a/Kernel/System/Auth/DB.pm
+++ b/Kernel/System/Auth/DB.pm
@@ -107,7 +107,7 @@ sub Auth {
     my $RemoteAddr  = $ParamObject->RemoteAddr() || 'Got no REMOTE_ADDR env!';
     my $UserID      = '';
     my $GetPw       = '';
-    my $Method;
+    my $Method      = '';
 
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
@@ -187,7 +187,7 @@ sub Auth {
             $EncodeObject->EncodeOutput( \$Pw );
             $SHAObject->add($Pw);
             $CryptedPw = $SHAObject->hexdigest();
-            $Method    = 'sha256';
+            $Method    = 'sha512';
         }
 
         elsif ( $GetPw =~ m{^BCRYPT:} ) {
@@ -198,7 +198,7 @@ sub Auth {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'error',
                     Message  =>
-                        "User: '$User' tried to authenticate with bcrypt but 'Crypt::Eksblowfish::Bcrypt' is not installed!",
+                        "User: $User tried to authenticate with bcrypt but 'Crypt::Eksblowfish::Bcrypt' is not installed!",
                 );
                 return;
             }
@@ -265,10 +265,19 @@ sub Auth {
 
     # just in case for debug!
     if ( $Self->{Debug} > 0 ) {
+        my $EnteredPw  = $CryptedPw;
+        my $ExpectedPw = $GetPw;
+
+        # Don't log plaintext passwords.
+        if ( $Method eq 'plain' ) {
+            $EnteredPw  = 'xxx';
+            $ExpectedPw = 'xxx';
+        }
+
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
             Message  =>
-                "User: '$User' tried to authenticate with Pw: '$Pw' ($UserID/$Method/$CryptedPw/$GetPw/$Salt/$RemoteAddr)",
+                "User: $User tried to authenticate (User ID: $UserID, method: $Method, entered password: $EnteredPw, expected password: $ExpectedPw, salt: $Salt, remote address: $RemoteAddr)",
         );
     }
 

--- a/Kernel/System/Auth/LDAP.pm
+++ b/Kernel/System/Auth/LDAP.pm
@@ -161,7 +161,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => "User: ($Param{User}) added $Self->{UserSuffix} to username!",
+                Message  => "User: $Param{User} added $Self->{UserSuffix} to username!",
             );
         }
     }
@@ -170,8 +170,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$Param{User}' tried to authenticate with Pw: '$Param{Pw}' "
-                . "(REMOTE_ADDR: $RemoteAddr)",
+            Message  => "User: $Param{User} tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 

--- a/Kernel/System/Auth/Radius.pm
+++ b/Kernel/System/Auth/Radius.pm
@@ -103,7 +103,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$User' tried to authenticate with Pw: '$Pw' ($RemoteAddr)",
+            Message  => "User: $User tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 

--- a/Kernel/System/CustomerAuth/LDAP.pm
+++ b/Kernel/System/CustomerAuth/LDAP.pm
@@ -159,7 +159,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => "CustomerUser: ($Param{User}) added $Self->{UserSuffix} to username!",
+                Message  => "CustomerUser: $Param{User} added $Self->{UserSuffix} to username!",
             );
         }
     }
@@ -168,8 +168,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "CustomerUser: '$Param{User}' tried to authenticate with Pw: '$Param{Pw}' "
-                . "(REMOTE_ADDR: $RemoteAddr)",
+            Message  => "CustomerUser: $Param{User} tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 
@@ -271,7 +270,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => 'check for groupdn!',
+                Message  => 'Checking for GroupDN.',
             );
         }
 

--- a/Kernel/System/CustomerAuth/Radius.pm
+++ b/Kernel/System/CustomerAuth/Radius.pm
@@ -106,7 +106,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$User' tried to authenticate with Pw: '$Pw' ($RemoteAddr)",
+            Message  => "CustomerUser: $User tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 
@@ -151,7 +151,7 @@ sub Auth {
     if ( defined($AuthResult) && $AuthResult == 1 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: $User Authentication ok (REMOTE_ADDR: $RemoteAddr).",
+            Message  => "CustomerUser: $User Authentication ok (REMOTE_ADDR: $RemoteAddr).",
         );
         return $User;
     }
@@ -160,7 +160,7 @@ sub Auth {
     else {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: $User Authentication with wrong Pw!!! (REMOTE_ADDR: $RemoteAddr)"
+            Message  => "CustomerUser: $User Authentication with wrong Pw!!! (REMOTE_ADDR: $RemoteAddr)"
         );
         return;
     }


### PR DESCRIPTION
Disable the logging of plaintext passwords in debugging mode.

This is inspired by CVE-2024-43444. I'd not consider this a security patch, as the debugging mode can only be enabled by changing the source code. And if you have access to the source code, you can debug anything.