### PR TITLE
Issue #3719: Use BuildSelectionDataGet to properly handle empty values in Reference fields.

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseReference.pm
+++ b/Kernel/System/DynamicField/Driver/BaseReference.pm
@@ -263,9 +263,14 @@ sub EditFieldRender {
 
         if ( $DFDetails->{MultiValue} ) {
             for my $ValueIndex ( 0 .. $#{$Value} ) {
+                my $DataValues = $Self->BuildSelectionDataGet(
+                    DynamicFieldConfig => $Param{DynamicFieldConfig},
+                    PossibleValues     => $PossibleValues,
+                    Value              => $Value->[$ValueIndex],
+                );
                 my $FieldID = $FieldName . '_' . $ValueIndex;
                 push @SelectionHTML, $Param{LayoutObject}->BuildSelection(
-                    Data       => $PossibleValues || {},
+                    Data       => $DataValues,
                     Sort       => 'AlphanumericValue',
                     Disabled   => $Param{Readonly},
                     Name       => $FieldName,
@@ -278,8 +283,13 @@ sub EditFieldRender {
         }
         else {
             my @SelectedIDs = grep {$_} $Value->@*;
+            my $DataValues  = $Self->BuildSelectionDataGet(
+                DynamicFieldConfig => $Param{DynamicFieldConfig},
+                PossibleValues     => $PossibleValues,
+                Value              => \@SelectedIDs,
+            );
             push @SelectionHTML, $Param{LayoutObject}->BuildSelection(
-                Data       => $PossibleValues || {},
+                Data       => $DataValues,
                 Sort       => 'AlphanumericValue',
                 Disabled   => $Param{Readonly},
                 Name       => $FieldName,


### PR DESCRIPTION
closes #3719