### PR TITLE
Issue #3753: import the default methods from Encode

### DIFF
--- a/Kernel/System/Encode.pm
+++ b/Kernel/System/Encode.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 
 # core modules
-use Encode ();
+use Encode;
 
 # CPAN modules
 use Encode::Locale;


### PR DESCRIPTION
at least 'decode()' is called