### PR TITLE
Issue #3753: the encode object can be copied

### DIFF
--- a/Kernel/System/EventHandler.pm
+++ b/Kernel/System/EventHandler.pm
@@ -292,8 +292,8 @@ sub EventHandlerTransaction {
         'Kernel::System::DB',
         'Kernel::Config',
         'Kernel::System::Log',
+        'Kernel::System::Encode',
     );
-
     for my $Object (@KeepObjects) {
         $Kernel::OM->{Objects}{$Object}            = $OuterOM->{Objects}{$Object};
         $Kernel::OM->{ObjectDependencies}{$Object} = $OuterOM->{ObjectDependencies}{$Object};


### PR DESCRIPTION
into the newly created object manager when
handling the transaction events