### PR TITLE
Issue #3682: workaround for the last line no longer needed

### DIFF
--- a/scripts/test/Console/Command/Admin/ImportExport/Export.t
+++ b/scripts/test/Console/Command/Admin/ImportExport/Export.t
@@ -163,7 +163,6 @@ ok( -e $ExportFilename, 'export file was finally generated' );
     my @ExpectedLines      = map {s/<<RANDOM_ID>>/$RandomID/r} $ExpectedResultFile->slurp;
     is( scalar @ExpectedLines, 22, 'got some expected content' );
     my @Lines = file($ExportFilename)->slurp;
-    $Lines[-1] .= "\n";
     is(
         \@Lines,
         \@ExpectedLines,


### PR DESCRIPTION
quite sensible, that last line of the CSV export now has a newline at the end of the line