### PR TITLE
Issue #3440: Logout after change of password

### DIFF
--- a/Kernel/Modules/AgentPreferences.pm
+++ b/Kernel/Modules/AgentPreferences.pm
@@ -109,7 +109,8 @@ sub Run {
             );
         }
 
-        my $SettingID = $ParamObject->GetParam( Param => 'SettingID' );
+        my $SettingID  = $ParamObject->GetParam( Param => 'SettingID' );
+        my $IsPwdReset = 0;
 
         for my $Group (@Groups) {
 
@@ -155,7 +156,10 @@ sub Run {
                 )
             {
                 $Message .= $Object->Message();
-                if ( $Preferences{$Group}->{NeedsReload} ) {
+                if ( $Group eq 'Password' && exists $GetParam{NewPw} && exists $GetParam{CurPw} ) {
+                    $IsPwdReset = 1;
+                }
+                elsif ( $Preferences{$Group}->{NeedsReload} ) {
                     $ConfigNeedsReload = 1;
                 }
             }
@@ -165,11 +169,27 @@ sub Run {
             }
         }
 
+        if ($IsPwdReset) {
+
+            # clear *all* sessions for this user (issue #3440)
+            my %UserData = $UserObject->GetUserData( UserID => $Self->{CurrentUserID} );
+
+            my $AuthSessionObject = $Kernel::OM->Get('Kernel::System::AuthSession');
+            if ( !$AuthSessionObject->RemoveSessionByUser( UserLogin => $UserData{UserLogin} ) ) {
+
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message  => "Could not delete sessions for user after pwd change.",
+                );
+            }
+        }
+
         my $JSON = $LayoutObject->JSONEncode(
             Data => {
                 'Message'     => $Message,
                 'Priority'    => $Priority,
-                'NeedsReload' => $ConfigNeedsReload
+                'NeedsReload' => $ConfigNeedsReload,
+                'ForceReload' => $IsPwdReset,
             },
         );
 

--- a/Kernel/Modules/BasePassword.pm
+++ b/Kernel/Modules/BasePassword.pm
@@ -21,6 +21,8 @@ package Kernel::Modules::BasePassword;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::Output::HTML::Layout',
@@ -161,6 +163,14 @@ sub Run {
             Key       => 'UserRequestedURL',
             Value     => '',
         );
+
+        # clear *all* sessions for this user (issue #3440)
+        if ( !$AuthSessionObject->RemoveSessionByUser( UserLogin => $UserData{UserLogin} ) ) {
+            $LayoutObject->FatalError(
+                Message => Translatable('Can`t remove SessionID.'),
+                Comment => Translatable('Please contact the administrator.'),
+            );    # throws a Kernel::System::Web::Exception
+        }
 
         # redirect to original requested url
         return $LayoutObject->Redirect( OP => "$Self->{UserRequestedURL}" );

--- a/Kernel/Modules/CustomerPreferences.pm
+++ b/Kernel/Modules/CustomerPreferences.pm
@@ -109,6 +109,18 @@ sub Run {
             $Message  = $Object->Error();
         }
 
+        if ( $Priority ne 'Error' && $Group eq 'Password' && exists $GetParam{NewPw} && exists $GetParam{CurPw} ) {
+
+            # clear *all* sessions for this user (issue #3440)
+            my $AuthSessionObject = $Kernel::OM->Get('Kernel::System::AuthSession');
+            if ( !$AuthSessionObject->RemoveSessionByUser( UserLogin => $UserData{UserLogin} ) ) {
+                $LayoutObject->FatalError(
+                    Message => Translatable('Can`t remove SessionID.'),
+                    Comment => Translatable('Please contact the administrator.'),
+                );    # throws a Kernel::System::Web::Exception
+            }
+        }
+
         # check redirect
         my $RedirectURL = $ParamObject->GetParam( Param => 'RedirectURL' );
         if ($RedirectURL) {

--- a/var/httpd/htdocs/js/Core.Agent.Preferences.js
+++ b/var/httpd/htdocs/js/Core.Agent.Preferences.js
@@ -133,6 +133,11 @@ Core.Agent.Preferences = (function (TargetNS) {
                             if (typeof Response.NeedsReload !== 'undefined' && parseInt(Response.NeedsReload, 10) > 0) {
                                 Core.UI.ShowNotification(Core.Language.Translate('Please note that at least one of the settings you have changed requires a page reload. Click here to reload the current screen.'), 'Notice', Link);
                             }
+
+                            // if browser reload is forced after password change (issue #3440)
+                            if (typeof Response.ForceReload !== 'undefined' && parseInt(Response.ForceReload, 10) > 0) {
+                                location.reload();
+                            }
                         }
                     }
                     else {


### PR DESCRIPTION
Changes:
- BasePassword handles non-ajax case used when pwd ttl is expired
- AgentPreferences and CustomerPreferences handle the std user resets pwd cases (ajax)
- Core.Agen.Preferences.js now reloads browser window after pwd change to make the session invalidation visible to the user