### PR TITLE
Issue #3769: fix and enhance profiling

### DIFF
--- a/bin/psgi-bin/otobo.psgi
+++ b/bin/psgi-bin/otobo.psgi
@@ -100,7 +100,7 @@ eval {
     require Net::DNS;
 };
 
-# for activating profiling
+# Activate profiling only when Plack::Middleware::Profiler::NYTProf is installed.
 my $ProfilingIsActive = 0;
 
 # The OTOBO home is determined from the location of otobo.psgi.
@@ -512,6 +512,7 @@ my $HtdocsApp = builder {
     }
     $SyncFromS3Middleware;
 
+    # serve static files without directory listing
     Plack::App::File->new( root => "$Home/var/httpd/htdocs" )->to_app();
 };
 
@@ -530,10 +531,40 @@ my $OTOBOApp = builder {
 
     # enable profiling only when Plack::Middleware::Profiler::NYTProf is installed
     if ($ProfilingIsActive) {
+
+        # Store the profile id also in a closed over variable,
+        # so that it is available in report_dir
+        my $ProfileID;
+
         enable 'Profiler::NYTProf',
 
+            # in case that only specific pages should be profiled
             #enable_profile => sub { return $Env->{QUERY_STRING} =~ m/NYTProf=([\w-]+)/ ? 1 : 0; }, # untested
-            report_dir => sub { return 'var/httpd/htdocs/nytprof' },
+
+            # Order by time, in order to make it easier looking at the latest report.
+            # Add a human readable timestamp.
+            # Add the process ID in order to see whether requests ran in the same process.
+            generate_profile_id => sub {
+                my ( $Minute, $Hour, $MonthDay, $MonthZeroBased ) = (gmtime)[ 1, 2, 3, 4 ];
+
+                $ProfileID = sprintf '%02d-%02d-%02d:%02d-%f-%d',
+                $MonthZeroBased + 1,
+                $MonthDay,
+                $Hour,
+                $Minute,
+                Time::HiRes::time(),
+                $$;
+
+                return $ProfileID;
+            },
+
+            # generate a new directory for each report
+            report_dir => sub {
+                my $ReportDir = "var/httpd/htdocs/nytprof/$ProfileID";
+                make_path($ReportDir);
+
+                return "var/httpd/htdocs/nytprof/$ProfileID";
+            },
             ;
     }
 
@@ -632,6 +663,9 @@ builder {
     # fixing PATH_INFO
     enable_if { ( $_[0]->{FCGI_ROLE} // '' ) eq 'RESPONDER' } $FixFCGIProxyMiddleware;
 
+    # directory listing for the nytprof directory
+    mount '/otobo-web/nytprof' => Plack::App::Directory->new( root => "$Home/var/httpd/htdocs/nytprof" )->to_app();
+
     # Server the static assets in var/httpd/htdocs.
     mount '/otobo-web' => $HtdocsApp;
 
@@ -650,11 +684,6 @@ builder {
     # some static pages, '/' is already translate to '/index.html'
     mount "/robots.txt" => Plack::App::File->new( file => "$Home/var/httpd/htdocs/robots.txt" )->to_app;
     mount "/index.html" => Plack::App::File->new( file => "$Home/var/httpd/htdocs/index.html" )->to_app;
-
-    # only useful for profiling
-    if ($ProfilingIsActive) {
-        mount '/nytprof' => Plack::App::Directory->new( root => "$Home/var/httpd/htdocs/nytprof" )->to_app();
-    }
 
     # otherwise an error 404 it thrown, which is handled by Plack::Middleware::ErrorDocument
 };


### PR DESCRIPTION
There was an error when profiling was deactivated, it propably had to do with the DSL syntax of Plack::Builder.
So let's enable the route /otobo-web/nytprof in all cases.

For convenience create a new report dir for every request. This offers the chance to see all requests, including the AJAX requests. Made a workaround to make the profile id available in the report dirname.

Enhance the profile id to show the human readable date and time.