### PR TITLE
Issue #3719: always sort select options so that empty value, if added…

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -5303,9 +5303,9 @@ sub RichTextDocumentComplete {
     );
 
     # verify HTML document
-    my $CustomerInterface = ($Self->{SessionSource} && ($Self->{SessionSource} eq 'CustomerInterface')) ? 1 : 0;
-    my $HTMLString = $Kernel::OM->Get('Kernel::System::HTMLUtils')->DocumentComplete(
-        String => $StringRef->$*,
+    my $CustomerInterface = ( $Self->{SessionSource} && ( $Self->{SessionSource} eq 'CustomerInterface' ) ) ? 1 : 0;
+    my $HTMLString        = $Kernel::OM->Get('Kernel::System::HTMLUtils')->DocumentComplete(
+        String            => $StringRef->$*,
         CustomerInterface => $CustomerInterface
     );
 
@@ -5918,10 +5918,21 @@ sub _BuildSelectionDataRefCreate {
             # already done before the translation
         }
         else {
+
+            # if empty value has been added, remove before sort
+            my $EmptyValue = delete $DataLocal->{''};
+
             @SortKeys = sort {
                 lc( $DataLocal->{$a} // '' )
                     cmp lc( $DataLocal->{$b} // '' )
             } ( keys %{$DataLocal} );
+
+            # if we had an empty value, put it back and add it's
+            # sort-key at the very beginning
+            if ( defined $EmptyValue ) {
+                $DataLocal->{''} = $EmptyValue;
+                unshift @SortKeys, '';
+            }
             $OptionRef->{Sort} = 'AlphanumericValue';
         }
 


### PR DESCRIPTION
…, always is listed first

Tried hard to find a pure frontend solution but at the frontend we currently do not have enough information to handle this properly, requiring bigger design changes than anticipated.

Thus settled for the "simple" path on the backend changing the sort order for generation of HTML option lists. 