### PR TITLE
Issue #3961: Added parameter to XSLT mapping calls to map undef values and empty strings to empty strings instead of empty hash refs.

### DIFF
--- a/Kernel/GenericInterface/Mapping/XSLT.pm
+++ b/Kernel/GenericInterface/Mapping/XSLT.pm
@@ -252,6 +252,9 @@ sub Map {
 
     my $XMLSimple = XML::Simple->new;
     my $XMLPre    = eval {
+
+        # Note that the default behavior for SuppressEmpty applies.
+        # This means that attributes with undefined values will be added as empty elements.
         $XMLSimple->XMLout(
             $Param{Data},
             AttrIndent => 1,
@@ -307,7 +310,6 @@ sub Map {
             KeyAttr    => [],
 
             # define how empty values (keys pointing to undef or an empty string) are mapped into XML
-            #   undef values will be added as empty elements
             SuppressEmpty => '',
         );
     };

--- a/Kernel/GenericInterface/Mapping/XSLT.pm
+++ b/Kernel/GenericInterface/Mapping/XSLT.pm
@@ -309,7 +309,7 @@ sub Map {
             NoAttr     => 1,
             KeyAttr    => [],
 
-            # define how empty values (keys pointing to undef or an empty string) are mapped into XML
+            # from XML to JSON map empty and undef values to '' instead of {}
             SuppressEmpty => '',
         );
     };

--- a/Kernel/GenericInterface/Mapping/XSLT.pm
+++ b/Kernel/GenericInterface/Mapping/XSLT.pm
@@ -254,12 +254,11 @@ sub Map {
     my $XMLPre    = eval {
         $XMLSimple->XMLout(
             $Param{Data},
-            AttrIndent    => 1,
-            ContentKey    => '-content',
-            NoAttr        => 1,
-            KeyAttr       => [],
-            RootName      => 'RootElement',
-            SuppressEmpty => '',
+            AttrIndent => 1,
+            ContentKey => '-content',
+            NoAttr     => 1,
+            KeyAttr    => [],
+            RootName   => 'RootElement',
         );
     };
     if ( !$XMLPre ) {
@@ -302,10 +301,13 @@ sub Map {
     my $ReturnData = eval {
         $XMLSimple->XMLin(
             $XMLPost,
-            ForceArray    => 0,
-            ContentKey    => '-content',
-            NoAttr        => 1,
-            KeyAttr       => [],
+            ForceArray => 0,
+            ContentKey => '-content',
+            NoAttr     => 1,
+            KeyAttr    => [],
+
+            # define how empty values (keys pointing to undef or an empty string) are mapped into XML
+            #   undef values will be added as empty elements
             SuppressEmpty => '',
         );
     };

--- a/Kernel/GenericInterface/Mapping/XSLT.pm
+++ b/Kernel/GenericInterface/Mapping/XSLT.pm
@@ -254,11 +254,12 @@ sub Map {
     my $XMLPre    = eval {
         $XMLSimple->XMLout(
             $Param{Data},
-            AttrIndent => 1,
-            ContentKey => '-content',
-            NoAttr     => 1,
-            KeyAttr    => [],
-            RootName   => 'RootElement',
+            AttrIndent    => 1,
+            ContentKey    => '-content',
+            NoAttr        => 1,
+            KeyAttr       => [],
+            RootName      => 'RootElement',
+            SuppressEmpty => '',
         );
     };
     if ( !$XMLPre ) {
@@ -301,10 +302,11 @@ sub Map {
     my $ReturnData = eval {
         $XMLSimple->XMLin(
             $XMLPost,
-            ForceArray => 0,
-            ContentKey => '-content',
-            NoAttr     => 1,
-            KeyAttr    => [],
+            ForceArray    => 0,
+            ContentKey    => '-content',
+            NoAttr        => 1,
+            KeyAttr       => [],
+            SuppressEmpty => '',
         );
     };
     if ( !$ReturnData ) {

--- a/scripts/test/GenericInterface/Mapping/XSLT.t
+++ b/scripts/test/GenericInterface/Mapping/XSLT.t
@@ -352,7 +352,7 @@ END_STYLESHEET
             ConfigSuccess => 1,
         },
         {
-            Name   => 'Roundtrip empty string, turned into empty hashref',
+            Name   => 'Roundtrip empty string, turned into empty string',
             Config => {
                 Template => $IdentityTransform,
             },
@@ -360,13 +360,13 @@ END_STYLESHEET
                 Key => q{},
             },
             ResultData => {
-                Key => {},
+                Key => '',
             },
             ResultSuccess => 1,
             ConfigSuccess => 1,
         },
         {
-            Name   => 'Roundtrip undef, turned into empty hashref',
+            Name   => 'Roundtrip undef, turned into empty string',
             Config => {
                 Template => $IdentityTransform,
             },
@@ -374,7 +374,7 @@ END_STYLESHEET
                 Key => undef,
             },
             ResultData => {
-                Key => {},
+                Key => '',
             },
             ResultSuccess => 1,
             ConfigSuccess => 1,


### PR DESCRIPTION
closes #3961