### PR TITLE
Issue #3939: Fix time accounting in context of article editing

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -6362,6 +6362,7 @@ sub TicketAccountTime {
         Data  => {
             TicketID  => $Param{TicketID},
             ArticleID => $Param{ArticleID},
+            TimeUnits => $Param{TimeUnit}
         },
         UserID => $Param{UserID},
     );

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -666,9 +666,9 @@ sub ArticleAccountedTimeGet {
             $TimeUnit =~ s/,/./g;
             $AccountedTime += $TimeUnit;
         }
-
-        return $AccountedTime;
     }
+
+    return $AccountedTime;
 }
 
 =head2 ArticleAccountedTimeDelete()


### PR DESCRIPTION
Currently article editing does not correctly account article times when more than one time is entered for an article. This PR fixes that error. Furthermore, the time of deleted articles is now shown on the ticket info.