### PR TITLE
Issue #211 - new .gitlab-ci.yml for GitLab 2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ variables:
   OTOBO_TESTS:
     value: "scripts/test/Ticket"
     description: "Specify single test or directory of Tests, starting with 'scrips/test'. "
+  OTOBO_PACKAGES:
+    value: ""
+    description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
+    
   OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
   # TODO: packacge might need /opt/otobo/Custom
   OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
@@ -61,8 +65,9 @@ testsuite:
     - apk update -q
     - apk add git -q   
 
-    # prepare otobo config
+    # prepare otobo sources
     - cp Kernel/Config.pm.docker.dist Kernel/Config.pm
+    - mkdir -p var/tmp
     - export OPT_OTOBO=$PWD
     - chown -R 1000:1000 .
 
@@ -94,11 +99,14 @@ testsuite:
     - docker exec otobo-web-1 bash -c 'bin/otobo.CheckModules.pl --finst=devel:test'
     
     # run quick_setup.pl
-    # TODO: consider FQDN
-    - docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_INSTALL_LIBS} cd /opt/otobo && /usr/local/bin/perl bin/docker/quick_setup.pl --db-password ${OTOBO_DB_ROOT_PASSWORD} --http-type http"
+    - docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_INSTALL_LIBS} cd /opt/otobo && /usr/local/bin/perl bin/docker/quick_setup.pl --db-password ${OTOBO_DB_ROOT_PASSWORD} --http-type http --fqdn 'localhost'"
     
     # extra Test dependencies for formatting test results in junit xml format
     - docker exec otobo-web-1 bash -c "/usr/local/bin/cpanm -n -q $TAP_FORMATTER 2>/dev/null"
+
+    # install packages, if any
+    - 'for PACKAGE in ${OTOBO_PACKAGES}; do echo "Install Package: $PACKAGE"; if [[ $PACKAGE != http* ]]; then PACKAGE="https://ftp.otobo.org/pub/otobo/packages/:$PACKAGE"  ;fi;  docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::Install "$PACKAGE"  ;done'
+    - docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::List
 
     # wait for login to become ready
     - docker exec otobo-web-1 bash -c 'TEST=""; while [ "$TEST" != "LoginButton"  ]; do echo "wait for login"; sleep 5; TEST=$(curl -s "http:/localhost:5000/otobo/index.pl" | grep -o "LoginButton"); done;'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,10 @@ default:
   - name: docker:24.0.5-dind
     alias: docker
   image: docker:24.0.5
+  
+stages:
+  - police
+  - test
 
 variables:
   # this disables HTTPS when talking to the docker daemon.
@@ -25,9 +29,12 @@ variables:
   OTOBO_PACKAGES:
     value: ""
     description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
-    
+  OTOBO_POLICE: ''
+  OTOBO_CHECK:
+    value: ""
+    description: "Arguments for codepolicy. to check only a single file, use '-f <filepath>'.\nUse '--list <filepath1> <filepath2> [...]' to check several file.\nUse '--all' to run all tests. \nLeave it empty to use the default of checking all files contained in the commit."    
   OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
-  # TODO: packacge might need /opt/otobo/Custom
+  # TODO: packacge might need /opt/otobo/Custom?
   OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
   OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/perl5/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
 
@@ -37,8 +44,50 @@ before_script:
   - if [ "$OTOBO_BASE" == "rel-10_0" ]; then export TAP_FORMATTER="TAP::Formatter::JUnit@0.13"; else export TAP_FORMATTER="TAP::Formatter::JUnit"; fi
   - echo "PIPELINE_SOURCE is $CI_PIPELINE_SOURCE"
 
-stages:
-  - test
+code_policy:
+  stage: police
+  image: ubuntu:24.04
+  # tags will determine which runners are allowed to pick up the job
+  tags:
+    - docker
+  script:
+
+    - echo "Going to call the ${OTOBO_POLICE} police for ${CI_PROJECT_NAME} branch ${CI_COMMIT_REF_NAME}."
+
+    # we need git plus some perl and tidy deps
+    - DEBIAN_FRONTEND=noninteractive apt-get update -qq -o=Dpkg::Use-Pty=0 > /dev/null
+    - DEBIAN_FRONTEND=noninteractive apt-get -qq -o=Dpkg::Use-Pty=0 install git cpanminus libcode-tidyall-perl libdbi-perl libnamespace-autoclean-perl hunspell libxml2-utils libtypes-serialiser-perl libtemplate-perl libdbix-connector-perl libdatetime-perl libtest2-suite-perl gettext libconst-fast-perl libperl-critic-community-perl libperl-critic-perl -y > /dev/null
+    - 'cpanm -n -q Perl::Critic::Policy::Variables::ProhibitUnusedVarsStricter'
+    
+    # determine version of codepolicy to use
+    - OTOBO_POLICE="$OTOBO_BASE"
+    - if [ "$OTOBO_POLICE" == "rel-11_1" ]; then OTOBO_POLICE="master"; fi
+
+    # clone the codepolicy repo
+    - 'git clone https://mit:${CI_POLIZEI_TOKEN}@git.otobo.org/rotheross/intern/codepolicy.git /opt/codepolicy'
+    - cd /opt/codepolicy
+    - git checkout $OTOBO_POLICE
+    - cd $CI_PROJECT_DIR
+
+    # if there were no explicit args to OTOBO_CHECK, determine defaults
+
+    # if we are on a release branch, check the files from last commit
+    # https://stackoverflow.com/questions/49853177/how-to-see-which-files-were-changed-in-last-commit
+    - if [ "$OTOBO_CHECK" == "" ] && [ "$OTOBO_BASE" == "$CI_COMMIT_REF_NAME" ] ; then OTOBO_CHECK="--list $(git diff --name-only HEAD HEAD~1)"; fi
+    - 'echo "CHECK: $OTOBO_CHECK"'
+
+    # otherwise, check the files that were modified compared to release branch (OTOBO_BASE)
+    # https://mlichtenberg.wordpress.com/2021/12/21/finding-everything-that-has-changed-in-a-git-branch/
+    - if [ "$OTOBO_CHECK" == "" ]; then OTOBO_CHECK="--list $(git diff --name-only $OTOBO_BASE...)"; fi
+    - 'echo "CHECK: $OTOBO_CHECK"'
+
+    # call the police now
+    - perl -I ../codepolicy -I ../codepolicy/Kernel/cpan-lib ../codepolicy/bin/otobo.CodePolicy.pl ${OTOBO_CHECK} 
+
+    # mark job as failed if we did tidy
+    - DID_TIDY=$(git diff | wc -l)
+    - git diff
+    - exit $DID_TIDY
 
 testsuite:
   stage: test
@@ -102,7 +151,7 @@ testsuite:
     - docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_INSTALL_LIBS} cd /opt/otobo && /usr/local/bin/perl bin/docker/quick_setup.pl --db-password ${OTOBO_DB_ROOT_PASSWORD} --http-type http --fqdn 'localhost'"
     
     # extra Test dependencies for formatting test results in junit xml format
-    - docker exec otobo-web-1 bash -c "/usr/local/bin/cpanm -n -q $TAP_FORMATTER 2>/dev/null"
+    - docker exec otobo-web-1 bash -c "/usr/local/bin/cpanm -n -q -f $TAP_FORMATTER 2>/dev/null"
 
     # install packages, if any
     - 'for PACKAGE in ${OTOBO_PACKAGES}; do echo "Install Package: $PACKAGE"; if [[ $PACKAGE != http* ]]; then PACKAGE="https://ftp.otobo.org/pub/otobo/packages/:$PACKAGE"  ;fi;  docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::Install "$PACKAGE"  ;done'
@@ -132,10 +181,7 @@ testsuite:
     
 after_script:
     # cleanup 
-    - cd /opt/otobo-docker
-    - docker compose down
-    - docker volume rm otobo_mariadb_data
-    - docker volume rm opt_otobo
+    - if [ -d /opt/otobo-docker ]; then cd /opt/otobo-docker; docker compose down; docker volume rm otobo_mariadb_data; docker volume rm opt_otobo; fi
     - echo "This was a build of ${CI_PROJECT_NAME} branch ${CI_COMMIT_REF_NAME} on otobo-docker:${OTOBO_BASE}. Over and out."
 
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,19 +124,18 @@ testsuite:
     # create the archive
     - docker exec otobo-web-1 bash -c "/opt/otobo/bin/otobo.CheckSum.pl -a create"
     
-    # run the tests    
-    - echo "Running tests from ${OTOBO_TESTS}"
+    # run the tests 
     - cd "$OPT_OTOBO"
-    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > rspec.xml; fi'
-    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "/opt/otobo/scripts/junit.pl";  fi;'
-    - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; touch rspec.xml; fi'
+    - echo "Running tests from ${OTOBO_TESTS}"
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}; /opt/otobo/scripts/junit.pl  "; fi'
+    - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; fi'
 
   # unit test report support - upload the test results to gitlab
   # https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html
   artifacts:
     when: always
     paths:
-      - "var/tap/**/*.junit.xml"
+      - "var/tap/**/*.rspec.xml"
     reports:
       junit: "var/tap/**/*.rspec.xml"
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,12 +3,11 @@
 # see https://docs.gitlab.com/ee/ci/docker/using_docker_build.html
 default:
   services:
-  - name: docker:24.0.5-dind
+  - name: docker:24.0.7-dind
     alias: docker
-  image: docker:24.0.5
+  image: docker:24.0.7
   
 stages:
-  - police
   - test
 
 variables:
@@ -29,14 +28,17 @@ variables:
   OTOBO_PACKAGES:
     value: ""
     description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
-  OTOBO_POLICE: ''
-  OTOBO_CHECK:
-    value: ""
-    description: "Arguments for codepolicy. to check only a single file, use '-f <filepath>'.\nUse '--list <filepath1> <filepath2> [...]' to check several file.\nUse '--all' to run all tests. \nLeave it empty to use the default of checking all files contained in the commit."    
   OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
   # TODO: packacge might need /opt/otobo/Custom?
   OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
-  OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/perl5/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
+  OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
+  OTOBO_JUNIT:
+    value: "1"
+    options:
+      - "1"
+      - "0"
+    description: "Use the TAP Formatter for JUnit test reports (default: 1)"
+
 
 before_script:
   # set variable TAP_FORMATTER depending on release branch.
@@ -44,53 +46,6 @@ before_script:
   - if [ "$OTOBO_BASE" == "rel-10_0" ]; then export TAP_FORMATTER="TAP::Formatter::JUnit@0.13"; else export TAP_FORMATTER="TAP::Formatter::JUnit"; fi
   - echo "PIPELINE_SOURCE is $CI_PIPELINE_SOURCE"
 
-code_policy:
-  stage: police
-  image: ubuntu:24.04
-  # tags will determine which runners are allowed to pick up the job
-  tags:
-    - docker
-  script:
-
-    - echo "Going to call the ${OTOBO_POLICE} police for ${CI_PROJECT_NAME} branch ${CI_COMMIT_REF_NAME}."
-
-    # we need git plus some perl and tidy deps
-    - DEBIAN_FRONTEND=noninteractive apt-get update -qq -o=Dpkg::Use-Pty=0 > /dev/null
-    - DEBIAN_FRONTEND=noninteractive apt-get -qq -o=Dpkg::Use-Pty=0 install git cpanminus libcode-tidyall-perl libdbi-perl libnamespace-autoclean-perl hunspell libxml2-utils libtypes-serialiser-perl libtemplate-perl libdbix-connector-perl libdatetime-perl libtest2-suite-perl gettext libconst-fast-perl libperl-critic-community-perl libperl-critic-perl -y > /dev/null
-    - 'cpanm -n -q Perl::Critic::Policy::Variables::ProhibitUnusedVarsStricter'
-    
-    # determine version of codepolicy to use
-    - OTOBO_POLICE="$OTOBO_BASE"
-    - if [ "$OTOBO_POLICE" == "rel-11_1" ]; then OTOBO_POLICE="master"; fi
-
-    # clone the codepolicy repo
-    - 'git clone https://mit:${CI_POLIZEI_TOKEN}@git.otobo.org/rotheross/intern/codepolicy.git /opt/codepolicy'
-    - cd /opt/codepolicy
-    - git checkout $OTOBO_POLICE
-    - cd $CI_PROJECT_DIR
-    - git fetch
-    - git checkout $OTOBO_BASE
-    - git checkout $CI_COMMIT_REF_NAME
-
-    # if there were no explicit args to OTOBO_CHECK, determine defaults
-
-    # if we are on a release branch, check the files from last commit
-    # https://stackoverflow.com/questions/49853177/how-to-see-which-files-were-changed-in-last-commit
-    - if [ "$OTOBO_CHECK" == "" ] && [ "$OTOBO_BASE" == "$CI_COMMIT_REF_NAME" ] ; then OTOBO_CHECK="--list $(git diff --name-only HEAD HEAD~1)"; fi
-    - 'echo "CHECK: $OTOBO_CHECK"'
-
-    # otherwise, check the files that were modified compared to release branch (OTOBO_BASE)
-    # https://mlichtenberg.wordpress.com/2021/12/21/finding-everything-that-has-changed-in-a-git-branch/
-    - if [ "$OTOBO_CHECK" == "" ]; then OTOBO_CHECK="--list $(git diff --name-only $OTOBO_BASE...)"; fi
-    - 'echo "CHECK: $OTOBO_CHECK"'
-
-    # call the police now
-    - perl -I /opt/codepolicy -I /opt/codepolicy/Kernel/cpan-lib /opt/codepolicy/bin/otobo.CodePolicy.pl ${OTOBO_CHECK} 
-
-    # mark job as failed if we did tidy
-    - DID_TIDY=$(git diff | wc -l)
-    - git diff
-    - exit $DID_TIDY
 
 testsuite:
   stage: test
@@ -120,6 +75,7 @@ testsuite:
     # prepare otobo sources
     - cp Kernel/Config.pm.docker.dist Kernel/Config.pm
     - mkdir -p var/tmp
+    - touch .copy_otobo_next_finished
     - export OPT_OTOBO=$PWD
     - chown -R 1000:1000 .
 
@@ -132,10 +88,10 @@ testsuite:
     - cp .docker_compose_env_http_selenium .env
     - sed -i "s/OTOBO_DB_ROOT_PASSWORD=/OTOBO_DB_ROOT_PASSWORD=${OTOBO_DB_ROOT_PASSWORD}/" .env
 
-    # create otobo volume for docker compose holding desired branch
-    # note: surround with single tick quotes to prevent being parsed as yaml
-    - 'docker volume create --driver local -o o=bind -o type=none -o device=$OPT_OTOBO  opt_otobo'
-    - 'sed -i "s/opt_otobo: {}/opt_otobo: { external: true }/" docker-compose/otobo-base.yml '
+    # mount local otobo folder
+    - sed -i "s~\- opt_otobo:/opt/otobo~[ ${PWD}:/opt/otobo ]~" docker-compose/otobo-base.yml
+    - 'sed -i "s/  opt_otobo: {}//" docker-compose/otobo-base.yml'
+    - cat docker-compose/otobo-base.yml
         
     # start containers
     - docker compose up --detach --quiet-pull
@@ -154,8 +110,9 @@ testsuite:
     - docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_INSTALL_LIBS} cd /opt/otobo && /usr/local/bin/perl bin/docker/quick_setup.pl --db-password ${OTOBO_DB_ROOT_PASSWORD} --http-type http --fqdn 'localhost'"
     
     # extra Test dependencies for formatting test results in junit xml format
-    - docker exec otobo-web-1 bash -c "/usr/local/bin/cpanm -n -q -f $TAP_FORMATTER 2>/dev/null"
-
+    
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 /usr/local/bin/cpanm --local-lib /opt/otobo/local -n -q -f $TAP_FORMATTER; fi'    
+    
     # install packages, if any
     - 'for PACKAGE in ${OTOBO_PACKAGES}; do echo "Install Package: $PACKAGE"; if [[ $PACKAGE != http* ]]; then PACKAGE="https://ftp.otobo.org/pub/otobo/packages/:$PACKAGE"  ;fi;  docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::Install "$PACKAGE"  ;done'
     - docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::List
@@ -171,7 +128,9 @@ testsuite:
     
     # run the tests    
     - echo "Running tests from ${OTOBO_TESTS}"
-    - docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /usr/local/bin/prove --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > $OPT_OTOBO/rspec.xml
+    - cd "$OPT_OTOBO"
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > rspec.xml; fi'
+    - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; touch rspec.xml; fi'
 
   # unit test report support - upload the test results to gitlab
   # https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html
@@ -184,7 +143,7 @@ testsuite:
     
 after_script:
     # cleanup 
-    - if [ -d /opt/otobo-docker ]; then cd /opt/otobo-docker; docker compose down; docker volume rm otobo_mariadb_data; docker volume rm opt_otobo; fi
+    - if [ -d /opt/otobo-docker ]; then cd /opt/otobo-docker; docker compose down; fi
     - echo "This was a build of ${CI_PROJECT_NAME} branch ${CI_COMMIT_REF_NAME} on otobo-docker:${OTOBO_BASE}. Over and out."
 
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,8 @@ code_policy:
     - git checkout $OTOBO_POLICE
     - cd $CI_PROJECT_DIR
     - git fetch
-    - git branch --all
+    - git checkout $OTOBO_BASE
+    - git checkout $CI_COMMIT_REF_NAME
 
     # if there were no explicit args to OTOBO_CHECK, determine defaults
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,6 @@ testsuite:
     # mount local otobo folder
     - sed -i "s~\- opt_otobo:/opt/otobo~[ ${OPT_OTOBO}:/opt/otobo ]~" docker-compose/otobo-base.yml
     - 'sed -i "s/  opt_otobo: {}//" docker-compose/otobo-base.yml'
-    - cat docker-compose/otobo-base.yml
         
     # start containers
     - docker compose up --detach --quiet-pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ code_policy:
     - cd /opt/codepolicy
     - git checkout $OTOBO_POLICE
     - cd $CI_PROJECT_DIR
-    - git fetch
+#    - git fetch
     - git checkout $OTOBO_BASE
     - git checkout $CI_COMMIT_REF_NAME
 
@@ -85,7 +85,7 @@ code_policy:
     - 'echo "CHECK: $OTOBO_CHECK"'
 
     # call the police now
-    - perl -I ../codepolicy -I ../codepolicy/Kernel/cpan-lib ../codepolicy/bin/otobo.CodePolicy.pl ${OTOBO_CHECK} 
+    - perl -I /opt/codepolicy -I /opt/codepolicy/Kernel/cpan-lib /opt/codepolicy/bin/otobo.CodePolicy.pl ${OTOBO_CHECK} 
 
     # mark job as failed if we did tidy
     - DID_TIDY=$(git diff | wc -l)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,7 @@ testsuite:
     - cp Kernel/Config.pm.docker.dist Kernel/Config.pm
     - mkdir -p var/tmp
     - touch .copy_otobo_next_finished
+    - 'mkdir -p var/tap'
     - export OPT_OTOBO=$PWD
     - chown -R 1000:1000 .
 
@@ -126,7 +127,6 @@ testsuite:
     # run the tests    
     - echo "Running tests from ${OTOBO_TESTS}"
     - cd "$OPT_OTOBO"
-    - 'mkdir -p $OPT_OTOBO/var/tap'
     - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > rspec.xml; fi'
     - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "/opt/otobo/scripts/junit.pl";  fi;'
     - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; touch rspec.xml; fi'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,8 @@ testsuite:
     # run the tests 
     - cd "$OPT_OTOBO"
     - echo "Running tests from ${OTOBO_TESTS}"
-    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}; /opt/otobo/scripts/junit.pl  "; fi'
+#    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}; PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/scripts/junit.pl  "; fi'
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/scripts/junit.pl ${OTOBO_TESTS} "; fi'
     - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; fi'
 
   # unit test report support - upload the test results to gitlab

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,6 @@ variables:
     value: ""
     description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
   OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
-  # TODO: packacge might need /opt/otobo/Custom?
   OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
   OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
   OTOBO_JUNIT:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ code_policy:
     - cd /opt/codepolicy
     - git checkout $OTOBO_POLICE
     - cd $CI_PROJECT_DIR
-#    - git fetch
+    - git fetch
     - git checkout $OTOBO_BASE
     - git checkout $CI_COMMIT_REF_NAME
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,9 @@ testsuite:
     # run the tests    
     - echo "Running tests from ${OTOBO_TESTS}"
     - cd "$OPT_OTOBO"
-    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > rspec.xml; fi'
+    - 'mkdir -p $OPT_OTOBO/var/tap'
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} PERL_TEST_HARNESS_DUMP_TAP=/opt/otobo/var/tap /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit ${OTOBO_TESTS}  " > rspec.xml; fi'
+    - 'if [ "$OTOBO_JUNIT" == "1" ]; then docker exec otobo-web-1 bash -c "/opt/otobo/scripts/junit.pl";  fi;'
     - 'if [ "$OTOBO_JUNIT" == "0" ]; then docker exec otobo-web-1 bash -c "PERL5LIB=${OTOBO_TEST_LIBS} /opt/otobo/bin/otobo.Console.pl Dev::UnitTest::Run --verbose ${OTOBO_TESTS}"; touch rspec.xml; fi'
 
   # unit test report support - upload the test results to gitlab
@@ -134,13 +136,14 @@ testsuite:
   artifacts:
     when: always
     paths:
-      - rspec.xml
+      - "var/tap/**/*.junit.xml"
     reports:
-      junit: rspec.xml
+      junit: "var/tap/**/*.rspec.xml"
     
 after_script:
     # cleanup 
-    - if [ -d /opt/otobo-docker ]; then cd /opt/otobo-docker; docker compose down; fi
+    - ' if [ -d /opt/otobo-docker ]; then cd /opt/otobo-docker; docker compose down; fi '
+    - ' if [ -d "$OPT_OTOBO/var/tap" ]; then rm -rf $OPT_OTOBO/var/tap; fi '
     - echo "This was a build of ${CI_PROJECT_NAME} branch ${CI_COMMIT_REF_NAME} on otobo-docker:${OTOBO_BASE}. Over and out."
 
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,8 @@ code_policy:
     - cd /opt/codepolicy
     - git checkout $OTOBO_POLICE
     - cd $CI_PROJECT_DIR
+    - git fetch
+    - git branch --all
 
     # if there were no explicit args to OTOBO_CHECK, determine defaults
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,8 +44,6 @@ before_script:
   # effectively this downgrades version for rel-10_0.
   - if [ "$OTOBO_BASE" == "rel-10_0" ]; then export TAP_FORMATTER="TAP::Formatter::JUnit@0.13"; else export TAP_FORMATTER="TAP::Formatter::JUnit"; fi
   - echo "PIPELINE_SOURCE is $CI_PIPELINE_SOURCE"
-  - echo "go"
-
 
 testsuite:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ before_script:
   # effectively this downgrades version for rel-10_0.
   - if [ "$OTOBO_BASE" == "rel-10_0" ]; then export TAP_FORMATTER="TAP::Formatter::JUnit@0.13"; else export TAP_FORMATTER="TAP::Formatter::JUnit"; fi
   - echo "PIPELINE_SOURCE is $CI_PIPELINE_SOURCE"
+  - echo "go"
 
 
 testsuite:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,18 +25,18 @@ variables:
   OTOBO_TESTS:
     value: "scripts/test/Ticket"
     description: "Specify single test or directory of Tests, starting with 'scrips/test'. "
-  OTOBO_PACKAGES:
-    value: ""
-    description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
-  OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
-  OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
-  OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
   OTOBO_JUNIT:
     value: "1"
     options:
       - "1"
       - "0"
     description: "Use the TAP Formatter for JUnit test reports (default: 1)"
+  OTOBO_PACKAGES:
+    value: ""
+    description: "Space separated list of versioned otobo packages names or full urls, e.g. 'Fred-11.0.1.opm' or 'https://ftp.otobo.org/pub/otobo/packages/:Fred-11.0.1.opm'\n See output of ./otobo.Console.pl Admin::Package::RepositoryList for possible values"
+  OTOBO_DB_ROOT_PASSWORD: "programmieren_auf_dem_bauernhof"
+  OTOBO_INSTALL_LIBS: '$PERL5LIB:/opt/otobo_install/otobo_next:/opt/otobo:/opt/otobo_install/otobo_next/Kernel/cpan-lib'
+  OTOBO_TEST_LIBS: '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib'
 
 
 before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ testsuite:
     - sed -i "s/OTOBO_DB_ROOT_PASSWORD=/OTOBO_DB_ROOT_PASSWORD=${OTOBO_DB_ROOT_PASSWORD}/" .env
 
     # mount local otobo folder
-    - sed -i "s~\- opt_otobo:/opt/otobo~[ ${PWD}:/opt/otobo ]~" docker-compose/otobo-base.yml
+    - sed -i "s~\- opt_otobo:/opt/otobo~[ ${OPT_OTOBO}:/opt/otobo ]~" docker-compose/otobo-base.yml
     - 'sed -i "s/  opt_otobo: {}//" docker-compose/otobo-base.yml'
     - cat docker-compose/otobo-base.yml
         

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,8 +73,8 @@ testsuite:
     # prepare otobo sources
     - cp Kernel/Config.pm.docker.dist Kernel/Config.pm
     - mkdir -p var/tmp
+    - mkdir -p var/tap
     - touch .copy_otobo_next_finished
-    - 'mkdir -p var/tap'
     - export OPT_OTOBO=$PWD
     - chown -R 1000:1000 .
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,10 +117,6 @@ testsuite:
     - 'for PACKAGE in ${OTOBO_PACKAGES}; do echo "Install Package: $PACKAGE"; if [[ $PACKAGE != http* ]]; then PACKAGE="https://ftp.otobo.org/pub/otobo/packages/:$PACKAGE"  ;fi;  docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::Install "$PACKAGE"  ;done'
     - docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::List
 
-    # install packages, if any
-    - 'for PACKAGE in ${OTOBO_PACKAGES}; do echo "Install Package: $PACKAGE"; if [[ $PACKAGE != http* ]]; then PACKAGE="https://ftp.otobo.org/pub/otobo/packages/:$PACKAGE"  ;fi;  docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::Install "$PACKAGE"  ;done'
-    - docker exec otobo-web-1 /opt/otobo/bin/otobo.Console.pl Admin::Package::List
-
     # wait for login to become ready
     - docker exec otobo-web-1 bash -c 'TEST=""; while [ "$TEST" != "LoginButton"  ]; do echo "wait for login"; sleep 5; TEST=$(curl -s "http:/localhost:5000/otobo/index.pl" | grep -o "LoginButton"); done;'
 

--- a/scripts/junit.pl
+++ b/scripts/junit.pl
@@ -1,0 +1,48 @@
+#!/usr/local/bin/perl
+
+use strict;
+use utf8;
+use XML::LibXSLT;
+use File::Find;
+
+# path to output of test reports
+my $Path = '/opt/otobo/var/tap';
+
+# find all *.t.junit.xml files under $Path, recursively
+my @Tests;
+find(
+    {
+        wanted => sub {
+            if ( $_ =~ /\.t.junit.xml$/ ) {
+                push @Tests, $_;
+                }
+        }, 
+        no_chdir => 1, 
+    },
+    $Path
+);
+
+# load the XSL style document
+my $StyleDoc = XML::LibXML->load_xml( location=>"/opt/otobo/scripts/junit.xsl", no_cdata=>1 ); 
+
+# prepare XSL transformer
+my $Xslt = XML::LibXSLT->new(); 
+my $Stylesheet = $Xslt->parse_stylesheet( $StyleDoc ); 
+
+# transform each Test output and save as *.t.rspec.xml
+foreach my $Test ( @Tests ) {
+    
+    
+    # load the source
+    my $Source = XML::LibXML->load_xml( location => "$Test" ); 
+    
+    # do the xsl transform
+    my $Results = $Stylesheet->transform( $Source ); 
+
+    # determine output file path
+    my $Output = $Test;
+    $Output =~ s/\.t\.junit\.xml/.t.rspec.xml/;
+    
+    # write enhanced xml file
+    $Stylesheet->output_file( $Results, $Output );
+}

--- a/scripts/junit.pl
+++ b/scripts/junit.pl
@@ -1,12 +1,54 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
+# Copyright (C) 2019-2024 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
 
 use strict;
+use warnings;
 use utf8;
 use XML::LibXSLT;
 use File::Find;
 
+# Arg 1 is path to Test(s)
+my $OtoboTests = $ARGV[0];
+
+if ( !$OtoboTests || $OtoboTests eq '' ) {
+    print STDERR "No tests specified!\n";
+    exit 1;
+}
+
 # path to output of test reports
-my $Path = '/opt/otobo/var/tap';
+my $TapPath = '/opt/otobo/var/tap';
+
+# prepare clean output paths
+system("rm -rf $TapPath");
+system("mkdir -p $TapPath");
+
+# lib paths for prove
+my $OtoboTestLibs = '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/local/lib/perl5/:/opt/otobo:/opt/otobo/Kernel/cpan-lib';
+
+#print STDERR "$OtoboTestLibs\n";
+#print STDERR "PERL5LIB=$OtoboTestLibs PERL_TEST_HARNESS_DUMP_TAP=$TapPath /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit $OtoboTests;\n";
+
+# run the test with prove and formatter
+my $ExitCode
+    = system("PERL5LIB=$OtoboTestLibs PERL_TEST_HARNESS_DUMP_TAP=$TapPath /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit $OtoboTests > /dev/null");
+
+#print STDERR "Exit Code: $ExitCode\n";
+
+# now transform results for GitLab
 
 # find all *.t.junit.xml files under $Path, recursively
 my @Tests;
@@ -15,34 +57,40 @@ find(
         wanted => sub {
             if ( $_ =~ /\.t.junit.xml$/ ) {
                 push @Tests, $_;
-                }
-        }, 
-        no_chdir => 1, 
+            }
+        },
+        no_chdir => 1,
     },
-    $Path
+    $TapPath
 );
 
 # load the XSL style document
-my $StyleDoc = XML::LibXML->load_xml( location=>"/opt/otobo/scripts/junit.xsl", no_cdata=>1 ); 
+my $StyleDoc = XML::LibXML->load_xml(
+    location => "/opt/otobo/scripts/junit.xsl",
+    no_cdata => 1
+);
 
 # prepare XSL transformer
-my $Xslt = XML::LibXSLT->new(); 
-my $Stylesheet = $Xslt->parse_stylesheet( $StyleDoc ); 
+my $Xslt       = XML::LibXSLT->new();
+my $Stylesheet = $Xslt->parse_stylesheet($StyleDoc);
 
 # transform each Test output and save as *.t.rspec.xml
-foreach my $Test ( @Tests ) {
-    
-    
+foreach my $Test (@Tests) {
+
     # load the source
-    my $Source = XML::LibXML->load_xml( location => "$Test" ); 
-    
+    my $Source = XML::LibXML->load_xml( location => "$Test" );
+
     # do the xsl transform
-    my $Results = $Stylesheet->transform( $Source ); 
+    my $Results = $Stylesheet->transform($Source);
 
     # determine output file path
     my $Output = $Test;
     $Output =~ s/\.t\.junit\.xml/.t.rspec.xml/;
-    
+
     # write enhanced xml file
     $Stylesheet->output_file( $Results, $Output );
+}
+
+if ( $ExitCode != 0 ) {
+    exit $ExitCode;
 }

--- a/scripts/junit.pl
+++ b/scripts/junit.pl
@@ -77,7 +77,7 @@ my $Stylesheet = $Xslt->parse_stylesheet($StyleDoc);
 # transform each Test output and save as *.t.rspec.xml
 foreach my $Test (@Tests) {
 
-    pritn STDERR "Transform $Test\n";
+    print STDERR "Transform $Test\n";
     # load the source
     my $Source = XML::LibXML->load_xml( location => "$Test" );
 
@@ -95,3 +95,4 @@ foreach my $Test (@Tests) {
 if ( $ExitCode != 0 ) {
     exit $ExitCode;
 }
+

--- a/scripts/junit.pl
+++ b/scripts/junit.pl
@@ -44,9 +44,9 @@ my $OtoboTestLibs = '$PERL5LIB:/opt/otobo/local/lib/perl5:/opt/otobo_install/loc
 
 # run the test with prove and formatter
 my $ExitCode
-    = system("PERL5LIB=$OtoboTestLibs PERL_TEST_HARNESS_DUMP_TAP=$TapPath /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit $OtoboTests > /dev/null");
+    = system("PERL5LIB=$OtoboTestLibs PERL_TEST_HARNESS_DUMP_TAP=$TapPath /usr/local/bin/prove -r --timer --formatter=TAP::Formatter::JUnit $OtoboTests "); # > /dev/null");
 
-#print STDERR "Exit Code: $ExitCode\n";
+print STDERR "Exit Code: $ExitCode\n";
 
 # now transform results for GitLab
 
@@ -77,6 +77,7 @@ my $Stylesheet = $Xslt->parse_stylesheet($StyleDoc);
 # transform each Test output and save as *.t.rspec.xml
 foreach my $Test (@Tests) {
 
+    pritn STDERR "Transform $Test\n";
     # load the source
     my $Source = XML::LibXML->load_xml( location => "$Test" );
 

--- a/scripts/junit.xsl
+++ b/scripts/junit.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--
+		Identity template, 
+        provides default behavior that copies all content into the output 
+    -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!--
+    	More specific template for tescase node that copies all attributes plus 
+    	generates the classname attribute from parent testsuite name attribute 
+     -->
+    <xsl:template match="testcase">
+    	<testcase>
+    	<xsl:attribute name="name"><xsl:value-of select="./@name"/></xsl:attribute>
+    	<xsl:attribute name="time"><xsl:value-of select="./@time"/></xsl:attribute>
+    	<xsl:attribute name="classname"><xsl:value-of select="../@name"/></xsl:attribute>
+    	</testcase>  
+    </xsl:template>
+</xsl:stylesheet>
+


### PR DESCRIPTION
*non urgent CI/CD improvements for GitLab 2.0 to be picked up when the next release train departs*

This change is for the rel-10_0 branch.

Please propagate this changes upwards to the other release branches.

When merging up, please change the default value for variable OTOBO_BASE in line 19

value: "rel-10_0"

to match the corresponding otobo-docker version. That is, for

rel-10_1 use rel-10_1
rel-11_0 use rel-11_0
rel_11_1 use rel-11_0

in other words set OTOBO_BASE to the release branch version, except for rel-11_1 which also uses the rel-11_0 otobo-docker image.

Please keep this dev branch open for a bit. There might be further tweaking ;-)