### PR TITLE
Issue #4235: also install 'gettext' in the container running CodePolicy

### DIFF
--- a/.github/workflows/code_policy.yml
+++ b/.github/workflows/code_policy.yml
@@ -17,7 +17,7 @@ jobs:
               uses: tj-actions/changed-files@v46
 
             - name: 'install dependencies'
-              run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install libxml2-utils libxslt-dev graphviz libqrencode-dev odbcinst1debian2 libodbc1 odbcinst unixodbc-dev unixodbc
+              run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install libxml2-utils libxslt-dev graphviz libqrencode-dev odbcinst1debian2 libodbc1 odbcinst unixodbc-dev unixodbc gettext
 
             # check out the merge commit of the pull request that triggerd this workflow
             - name: 'check out OTOBO'


### PR DESCRIPTION
because 'gettext' provided 'msgfmt' which is needed in TidyAll::Plugin::OTOBO::PO::msgfmt