### PR TITLE
Issue #3615: treat Type::Serialiser booleans just like plain scalars

### DIFF
--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -28,8 +28,9 @@ use utf8;
 use List::Util qw(shuffle);
 
 # CPAN modules
-use DBI             ();
-use DBIx::Connector ();
+use DBI               ();
+use DBIx::Connector   ();
+use Types::Serialiser ();
 
 # OTOBO modules
 use Kernel::System::VariableCheck qw(:all);
@@ -499,18 +500,27 @@ sub Error {
 
 to insert, update or delete values
 
-    my $InsertSuccess = $DBObject->Do( SQL => "INSERT INTO table (name) VALUES ('dog')" );
+    my $InsertSuccess = $DBObject->Do( SQL => "INSERT INTO list_of_mammals (name) VALUES ('dog')" );
 
-    my $DeleteSuccess = $DBObject->Do( SQL => "DELETE FROM table" );
+    my $DeleteSuccess = $DBObject->Do( SQL => "DELETE FROM list_of_mammals" );
 
-you also can use DBI bind values (used for large strings):
+you also can use DBI bind values. The usage of bind values is recommended for avoiding SQL injections
+and for passing long strings. Bind variables are passed as reference to plain scalars.
 
-    my $Var1 = 'dog1';
-    my $Var2 = 'dog2';
+Boolean values that are supported by C<Types::Serialiser> can be passed as well. Just like
+simple scalars, these must be passed by reference.
+
+    my $Var1 = 'Balto'; # serum run to Nome in 1925
+    my $Var2 = 'Togo';  # also serum run to Nome in 1925
 
     my $InsertSuccess = $DBObject->Do(
-        SQL  => "INSERT INTO table (name1, name2) VALUES (?, ?)",
-        Bind => [ \$Var1, \$Var2 ],
+        SQL  => "INSERT INTO pack_of_hounds (name1, name2, howl_loudly, are_vegan ) VALUES (?, ?)",
+        Bind => [
+            \$Var1,
+            \$Var2,
+            \$Types::Serialiser::true,
+            \Types::Serialiser::as_bool('')
+        ],
     );
 
 The special value B<current_timestamp> is replaced by the current date and time.
@@ -537,13 +547,16 @@ sub Do {
     if ( $Param{Bind} ) {
         for my $Data ( $Param{Bind}->@* ) {
             if ( ref $Data eq 'SCALAR' ) {
-                push @Array, $$Data;
+                push @Array, $Data->$*;
+            }
+            elsif ( ref $Data eq 'REF' && Types::Serialiser::is_bool( $Data->$* ) ) {
+                push @Array, $Data->$*;
             }
             else {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Caller   => 1,
                     Priority => 'Error',
-                    Message  => 'No SCALAR param in Bind!',
+                    Message  => qq{Invalid reference type in Bind!},
                 );
 
                 return;
@@ -876,6 +889,9 @@ sub Prepare {
             my $RefType = ref $Data;
             if ( $RefIsValid{$RefType} ) {
                 push @BindVariables, $DoArray ? $Data : $Data->$*;
+            }
+            elsif ( !$DoArray && $RefType eq 'REF' && Types::Serialiser::is_bool( $Data->$* ) ) {
+                push @BindVariables, $Data->$*;
             }
             else {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(

--- a/scripts/test/DB/Smallint.t
+++ b/scripts/test/DB/Smallint.t
@@ -22,7 +22,9 @@ use utf8;
 
 # CPAN modules
 use Test2::V0;
-use Data::Peek qw(DDump);
+use Data::Peek        qw(DDump);
+use JSON::PP          ();
+use Types::Serialiser ();
 
 # OTOBO modules
 use Kernel::System::UnitTest::RegisterOM;    # set up $Kernel::OM
@@ -87,21 +89,60 @@ my @Tests = (
         Data          => 32768,
         InsertSuccess => 0,
     },
+
+    # Booleans
+    {
+        Name          => '$JSON::PP::true',
+        Data          => $JSON::PP::true,
+        ExpectedValue => 1,
+    },
+    {
+        Name          => 'JSON::PP::true()',
+        Data          => JSON::PP::true(),
+        ExpectedValue => 1,
+    },
+    {
+        Name          => '$JSON::PP::false',
+        Data          => $JSON::PP::false,
+        ExpectedValue => 0,
+    },
+    {
+        Name          => 'JSON::PP::false()',
+        Data          => JSON::PP::false(),
+        ExpectedValue => 0,
+    },
+    {
+        Name          => '$Types::Serialiser::true',
+        Data          => $Types::Serialiser::true,
+        ExpectedValue => 1,
+    },
+    {
+        Name          => 'Types::Serialiser::true()',
+        Data          => Types::Serialiser::true(),
+        ExpectedValue => 1,
+    },
+    {
+        Name          => '$Types::Serialiser::false',
+        Data          => $Types::Serialiser::false,
+        ExpectedValue => 0,
+    },
+    {
+        Name          => 'Types::Serialiser::false()',
+        Data          => Types::Serialiser::false(),
+        ExpectedValue => 0,
+    },
 );
 
 for my $Test (@Tests) {
 
     subtest $Test->{Name} => sub {
 
-        my $TestData = $Test->{Data};
-
+        my @BindVariables = ( \$Test->{Data} );
         my $InsertSuccess = 0;
         my $InsertLives   = lives {
             $InsertSuccess = $DBObject->Do(
                 SQL  => 'INSERT INTO test_smallint_table ( test_smallint ) VALUES ( ? )',
-                Bind => [
-                    \$TestData,
-                ],
+                Bind => \@BindVariables,
             );
         };
         ok( $InsertLives, 'Insert() did not throw an exception' );
@@ -116,28 +157,28 @@ for my $Test (@Tests) {
 
         # Fetch without WHERE
         $DBObject->Prepare(
-            SQL   => 'SELECT test_smallint FROM test_smallint_table',
-            Limit => 1,
+            SQL => 'SELECT test_smallint FROM test_smallint_table',
         );
 
         my $RowCount = 0;
         while ( my ($RetrievedSmallint) = $DBObject->FetchrowArray ) {
             diag 'RetrievedSmallint: ', scalar DDump $RetrievedSmallint;
-            is( $RetrievedSmallint, $TestData, 'SELECT test_smallint' );
+            my $ExpectedSmallint = $Test->{ExpectedValue} // $Test->{Data};
+            is( $RetrievedSmallint, $ExpectedSmallint, 'SELECT test_smallint' );
             $RowCount++;
         }
         is( $RowCount, 1, 'only one row found' );
 
         # Fetch one row with WHERE
         $DBObject->Prepare(
-            SQL   => 'SELECT test_smallint FROM test_smallint_table WHERE test_smallint = ?',
-            Bind  => [ \$TestData, ],
-            Limit => 1,
+            SQL  => 'SELECT test_smallint FROM test_smallint_table WHERE test_smallint = ?',
+            Bind => \@BindVariables,
         );
 
         $RowCount = 0;
         while ( my ($RetrievedSmallint) = $DBObject->FetchrowArray ) {
-            is( $RetrievedSmallint, $TestData, "SELECT test_smallint with WHERE" );
+            my $ExpectedSmallint = $Test->{ExpectedValue} // $Test->{Data};
+            is( $RetrievedSmallint, $ExpectedSmallint, "SELECT test_smallint with WHERE" );
             $RowCount++;
         }
         is( $RowCount, 1, 'only one row found with WHERE' );


### PR DESCRIPTION
These booleans behave mostly like 0 and 1 anyways. They also have to be passed by reference, which is a bit confusing as the booleans are already implemented as blessed references.