### PR TITLE
Issue #4321: Used internal object type name instead of display name in dynamic field clone link.

### DIFF
--- a/Kernel/Modules/AdminDynamicField.pm
+++ b/Kernel/Modules/AdminDynamicField.pm
@@ -549,7 +549,7 @@ sub _DynamicFieldsListShow {
                             Valid          => $Valid,
                             ConfigDialog   => $ConfigDialog,
                             FieldTypeName  => $FieldTypeName,
-                            ObjectTypeName => $ObjectTypeName,
+                            ObjectTypeName => $DynamicFieldData->{ObjectType},
                         },
                     );
                 }


### PR DESCRIPTION
closes #4321

affects: https://github.com/RotherOSS/itsmconfigurationmanagement