### PR TITLE
Allow namespaced DFs in statistics to be dereferenced

### DIFF
--- a/Kernel/System/Stats/Dynamic/TicketList.pm
+++ b/Kernel/System/Stats/Dynamic/TicketList.pm
@@ -1343,7 +1343,7 @@ sub GetStatTable {
         $Ticket{NumberOfArticles}            ||= 0;
 
         for my $ParameterName ( sort keys %Ticket ) {
-            if ( $ParameterName =~ m{\A DynamicField_ ( [a-zA-Z\d]+ ) \z}xms ) {
+            if ( $ParameterName =~ m{\A DynamicField_ ( [a-zA-Z\d\-]+ ) \z}xms ) {
 
                 # loop over the dynamic fields configured
                 DYNAMICFIELD:


### PR DESCRIPTION
Adds the namespace separator.
Fixes #4353

Feel free to add tests as needed.