### PR TITLE
Add zstd to backup/restore script

### DIFF
--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -103,6 +103,11 @@ if ( $CompressOption && $CompressOption =~ m/bzip2/i ) {
     $CompressCMD = 'bzip2';
     $CompressEXT = 'bz2';
 }
+if ( $CompressOption && $CompressOption =~ m/zstd/i ) {
+    $Compress    = '-zstd';
+    $CompressCMD = 'zstd';
+    $CompressEXT = 'zst';
+}
 
 # check backup type
 my ( $DBOnlyBackup, $FullBackup, $MigrateFromOTRSBackup ) = ( 0, 0, 0 );

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -858,8 +858,8 @@ Usage:
 
     # for regular backups, can also be used in a cron job
     otobo> cd /opt/otobo
-    otobo> scripts/backup.pl -d /data_backup_dir [-c gzip|bzip2] [-r DAYS] [-t fullbackup|nofullbackup|dbonly]
-    otobo> scripts/backup.pl --backup-dir /data_backup_dir [--compress gzip|bzip2] [--remove-old-backups DAYS] [--backup-type fullbackup|nofullbackup|dbonly|migratefromotrs]
+    otobo> scripts/backup.pl -d /data_backup_dir [-c gzip|bzip2|zstd] [-r DAYS] [-t fullbackup|nofullbackup|dbonly]
+    otobo> scripts/backup.pl --backup-dir /data_backup_dir [--compress gzip|bzip2|zstd] [--remove-old-backups DAYS] [--backup-type fullbackup|nofullbackup|dbonly|migratefromotrs]
 
     # backups for creating a dump for migrating an OTRS database OTOBO
     otobo> cd /opt/otobo
@@ -871,7 +871,7 @@ Usage:
 Short options:
  [-h]                   - Display help for this command.
  [-d]                   - Directory where the backup files should be placed. Defauls to the current dir.
- [-c]                   - Select the compression method (gzip|bzip2). Defaults to gzip.
+ [-c]                   - Select the compression method (gzip|bzip2|zstd). Defaults to gzip.
  [-r DAYS]              - Remove backups which are more than DAYS days old.
  [-t]                   - Specify which data will be saved (fullbackup|nofullbackup|dbonly|migratefromotrs). Default: fullbackup.
 

--- a/scripts/restore.pl
+++ b/scripts/restore.pl
@@ -80,6 +80,9 @@ my $DecompressCMD = '';
 if ( -e File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.bz2' ) ) {
     $DecompressCMD = 'bunzip2';
 }
+elsif ( -e File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.zst' ) ) {
+    $DecompressCMD = 'zstd';
+}
 else {
     $DecompressCMD = 'gunzip';
 }
@@ -103,6 +106,7 @@ chdir( $Opts{d} );
 
 my $ConfigBackupGz  = File::Spec->catfile( $Opts{b}, 'Config.tar.gz' );
 my $ConfigBackupBz2 = File::Spec->catfile( $Opts{b}, 'Config.tar.bz2' );
+my $ConfigBackupZstd = File::Spec->catfile( $Opts{b}, 'Config.tar.zst' );
 if ( -e $ConfigBackupGz ) {
     say "Restore $ConfigBackupGz ...";
     system("tar -xzf $ConfigBackupGz");
@@ -111,6 +115,11 @@ elsif ( -e $ConfigBackupBz2 ) {
     say "Restore $ConfigBackupBz2 ...";
     system("tar -xjf $ConfigBackupBz2");
 }
+elsif ( -e $ConfigBackupZstd ) {
+    say "Restore $ConfigBackupZstd ...";
+    system("tar --zstd -xf $ConfigBackupZstd");
+}
+
 
 # create common objects
 local $Kernel::OM = Kernel::System::ObjectManager->new(
@@ -212,6 +221,7 @@ chdir($Home);
 # extract application
 my $ApplicationBackupGz  = File::Spec->catfile( $Opts{b}, 'Application.tar.gz' );
 my $ApplicationBackupBz2 = File::Spec->catfile( $Opts{b}, 'Application.tar.bz2' );
+my $ApplicationBackupZstd = File::Spec->catfile( $Opts{b}, 'Application.tar.zst' );
 if ( -e $ApplicationBackupGz ) {
     say "Restore $ApplicationBackupGz ...";
     system("tar -xzf $ApplicationBackupGz");
@@ -220,10 +230,15 @@ elsif ( -e $ApplicationBackupBz2 ) {
     say "Restore $ApplicationBackupBz2 ...";
     system("tar -xjf $ApplicationBackupBz2");
 }
+elsif ( -e $ApplicationBackupZstd ) {
+    say "Restore $ApplicationBackupZstd ...";
+    system("tar --zstd -xf $ApplicationBackupZstd");
+}
 
 # extract vardir
 my $VarDirBackupGz  = File::Spec->catfile( $Opts{b}, 'VarDir.tar.gz' );
 my $VarDirBackupBz2 = File::Spec->catfile( $Opts{b}, 'VarDir.tar.bz2' );
+my $VarDirBackupZstd = File::Spec->catfile( $Opts{b}, 'VarDir.tar.zst' );
 if ( -e $VarDirBackupGz ) {
     say "Restore $VarDirBackupGz ...";
     system("tar -xzf $VarDirBackupGz");
@@ -232,10 +247,15 @@ elsif ( -e $VarDirBackupBz2 ) {
     say "Restore $VarDirBackupBz2 ...";
     system("tar -xjf $VarDirBackupBz2");
 }
+elsif ( -e $VarDirBackupZstd ) {
+    say "Restore $VarDirBackupZstd ...";
+    system("tar --zstd -xf $VarDirBackupZstd");
+}
 
 # extract datadir
 my $DataDirBackupGz  = File::Spec->catfile( $Opts{b}, 'DataDir.tar.gz' );
 my $DataDirBackupBz2 = File::Spec->catfile( $Opts{b}, 'DataDir.tar.bz2' );
+my $DataDirBackupZstd = File::Spec->catfile( $Opts{b}, 'DataDir.tar.zst' );
 if ( -e $DataDirBackupGz ) {
     say "Restore $DataDirBackupGz ...";
     system("tar -xzf $DataDirBackupGz");
@@ -244,10 +264,15 @@ if ( -e $DataDirBackupBz2 ) {
     say "Restore $DataDirBackupBz2 ...";
     system("tar -xjf $DataDirBackupBz2");
 }
+if ( -e $DataDirBackupZstd ) {
+    say "Restore $DataDirBackupZstd ...";
+    system("tar --zstd -xf $DataDirBackupZstd");
+}
 
 # import database
 my $DatabaseBackupGz  = File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.gz' );
 my $DatabaseBackupBz2 = File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.bz2' );
+my $DatabaseBackupZstd = File::Spec->catfile( $Opts{b}, 'DatabaseBackup.sql.zst' );
 if ( $DB =~ m/mysql/i ) {
     say "create $DB";
     if ($DatabasePw) {
@@ -263,6 +288,12 @@ if ( $DB =~ m/mysql/i ) {
         say "Restore database into $DB ...";
         system(
             "bunzip2 -c $DatabaseBackupBz2 | mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database"
+        );
+    }
+    elsif ( -e $DatabaseBackupZstd ) {
+        say "Restore database into $DB ...";
+        system(
+            "zstd -dcf $DatabaseBackupZstd | mysql -f -u$DatabaseUser $DatabasePw -h$DatabaseHost $Database"
         );
     }
 }
@@ -291,6 +322,17 @@ else {
         say "Restore database into $DB ...";
         system(
             "bunzip2 -c $DatabaseBackupBz2 | psql -U$DatabaseUser $DatabaseHost $Database"
+        );
+    }
+    elsif ( -e $DatabaseBackupZstd ) {
+
+        # set password via environment variable if there is one
+        if ($DatabasePw) {
+            $ENV{PGPASSWORD} = $DatabasePw;    ## no critic qw(Variables::RequireLocalizedPunctuationVars)
+        }
+        say "Restore database into $DB ...";
+        system(
+            "zstd -dcf $DatabaseBackupZstd | psql -U$DatabaseUser $DatabaseHost $Database"
         );
     }
 }


### PR DESCRIPTION
To speed up the backup process one might wanna use zstd instead of bzip2(extremly slow) or gzip(ok but still slower...).

You could of course check it with `time` but here are some outputs i ran after a first test migration from the old otrs system.

As an overview:
- **zstd** ~4min
- **gzip** ~10min
- **bzip2** ~31min

The size of the mysql-directory and the backups (
```
root@otobo ~ # du -sh /var/lib/mysql/otobo/ /mnt/kp_bak/otobo/otobo/2025-05-27_0*/Database*
14G     /var/lib/mysql/otobo/
6.1G    /mnt/kp_bak/otobo/otobo/2025-05-27_01-54-04/DatabaseBackup.sql.zst
7.0G    /mnt/kp_bak/otobo/otobo/2025-05-27_01-59-38/DatabaseBackup.sql.gz
6.6G    /mnt/kp_bak/otobo/otobo/2025-05-27_02-16-00/DatabaseBackup.sql.bz2
```

```
root@otobo ~ # journalctl --no-hostname --unit otobo-backup.service --since 02:00
May 27 03:54:04 systemd[1]: Started otobo-backup.service - otobo backup.
May 27 03:54:04 backup.pl[8140]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_01-54-04/Config.tar.zst ... done
May 27 03:54:05 backup.pl[8140]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_01-54-04/Application.tar.zst ... done
May 27 03:54:05 backup.pl[8140]: Dumping mysql data to /mnt/kp_bak/otobo/otobo/2025-05-27_01-54-04/DatabaseBackup.sql.zst ...
May 27 03:58:26 backup.pl[8140]: done
May 27 03:58:26 systemd[1]: otobo-backup.service: Deactivated successfully.
May 27 03:58:26 systemd[1]: otobo-backup.service: Consumed 3min 49.281s CPU time.
May 27 03:59:38 systemd[1]: Started otobo-backup.service - otobo backup.
May 27 03:59:38 backup.pl[8226]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_01-59-38/Config.tar.gz ... done
May 27 03:59:45 backup.pl[8226]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_01-59-38/Application.tar.gz ... done
May 27 03:59:45 backup.pl[8226]: Dumping mysql data to /mnt/kp_bak/otobo/otobo/2025-05-27_01-59-38/DatabaseBackup.sql.gz ...
May 27 04:08:52 backup.pl[8226]: done
May 27 04:08:52 systemd[1]: otobo-backup.service: Deactivated successfully.
May 27 04:08:52 systemd[1]: otobo-backup.service: Consumed 10min 12.369s CPU time.
May 27 04:15:59 systemd[1]: Started otobo-backup.service - otobo backup.
May 27 04:16:00 backup.pl[8488]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_02-16-00/Config.tar.bz2 ... done
May 27 04:16:21 backup.pl[8488]: Backup /mnt/kp_bak/otobo/otobo/2025-05-27_02-16-00/Application.tar.bz2 ... done
May 27 04:16:21 backup.pl[8488]: Dumping mysql data to /mnt/kp_bak/otobo/otobo/2025-05-27_02-16-00/DatabaseBackup.sql.bz2 ...
May 27 04:47:16 backup.pl[8488]: done
May 27 04:47:16 systemd[1]: otobo-backup.service: Deactivated successfully.
May 27 04:47:16 systemd[1]: otobo-backup.service: Consumed 31min 51.304s CPU.
```
<details>
  <summary>The systemd unit's for anyone who's interested.</summary>

```
root@otobo ~ # systemctl cat otobo-backup.{service,timer}
# /etc/systemd/system/otobo-backup.service
[Unit]
Description=otobo backup
RequiresMountsFor=/mnt/kp_bak/otobo

[Service]
Type=simple
User=otobo
Environment=BACKUPDIR=/mnt/kp_bak/otobo/otobo
Environment=COMPRESSION=zstd
Environment=DAYS=31
Environment=TYPE=fullbackup
ExecStart=/opt/otobo/scripts/backup.pl --backup-dir ${BACKUPDIR}  --compress ${COMPRESSION} --remove-old-backups ${DAYS} --backup-type ${TYPE}

[Install]
WantedBy=default.target


# /etc/systemd/system/otobo-backup.timer
[Unit]
Description=Otobo Backup

[Timer]
OnCalendar=daily
RandomizedDelaySec=1h
Persistent=true

[Install]
WantedBy=timers.target
```
</details>