### PR TITLE
Issue #4393: prevent wrong loginform from being displayed 

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -6709,8 +6709,10 @@ sub _HasOnlyOIDCAuthModules {
     COUNT:
     for my $Count ( '', 1 .. 10 ) {
 
-        my $Module = $ConfigObject->Get('AuthModule$Count');
+        my $Module = $ConfigObject->Get("AuthModule$Count");
+
         if ($Module && $Module ne 'Kernel::System::Auth::OpenIDConnect') {
+
             return 0;
         }
     }

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -934,12 +934,15 @@ sub Login {
         XLoginHeader => 1,
     );
 
+    $Param{DisableStandardLogin} = $Self->_HasOnlyOIDCAuthModules();
+
     # create & return output
     return $Self->Output(
         TemplateFile => 'Login',
         Data         => \%Param,
     );
 }
+
 
 sub ChallengeTokenCheck {
     my ( $Self, %Param ) = @_;
@@ -6697,5 +6700,23 @@ sub SetCookie {
 
     return 1;
 }
+
+sub _HasOnlyOIDCAuthModules {
+    my ( $Self, %Param ) = @_;
+
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    COUNT:
+    for my $Count ( '', 1 .. 10 ) {
+
+        my $Module = $ConfigObject->Get('AuthModule$Count');
+        if ($Module && $Module ne 'Kernel::System::Auth::OpenIDConnect') {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 
 1;

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -203,9 +203,9 @@
                     <a href="#" id="LostPassword">[% Translate("Lost your password?") | html %]</a>
                 </p>
 [% RenderBlockEnd("LostPasswordLink") %]
+[% END %]
             </div>
 [% RenderBlockEnd("LoginBox") %]
-[% END %]
 
 [% RenderBlockStart("LostPassword") %]
             <div id="PasswordBox" class="Hidden">

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -198,7 +198,6 @@
                         </form>
                     </div>
                 </div>
-[% END %]
 [% RenderBlockStart("LostPasswordLink") %]
                 <p class="Center SpacingTop">
                     <a href="#" id="LostPassword">[% Translate("Lost your password?") | html %]</a>
@@ -206,6 +205,7 @@
 [% RenderBlockEnd("LostPasswordLink") %]
             </div>
 [% RenderBlockEnd("LoginBox") %]
+[% END %]
 
 [% RenderBlockStart("LostPassword") %]
             <div id="PasswordBox" class="Hidden">

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -140,6 +140,7 @@
                 <div class="[% IF Data.MessageType == 'Success' %]SuccessBox[% ELSIF Data.MessageType == 'Error' %]ErrorBox[% END %]">
                     <span>[% Translate(Data.Message) | html %]</span>
                 </div>
+[% IF !Data.DisableStandardLogin %]
                 <div class="WidgetSimple">
                     <div class="Content">
                         <p class="Error Center Spacing"></p>
@@ -197,6 +198,7 @@
                         </form>
                     </div>
                 </div>
+[% END %]
 [% RenderBlockStart("LostPasswordLink") %]
                 <p class="Center SpacingTop">
                     <a href="#" id="LostPassword">[% Translate("Lost your password?") | html %]</a>

--- a/Kernel/System/Auth/OpenIDConnect.pm
+++ b/Kernel/System/Auth/OpenIDConnect.pm
@@ -155,7 +155,7 @@ sub Auth {
     # check the state
     my $RandLength = $OpenIDConfig->{Misc}{RandLength} // $Self->{DefaultRandLength};
     my $StateCSRF  = substr $GetParam{State}, 0, $RandLength;
-    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF' );
+    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-'.$StateCSRF );
     my %StateCache = (
         Type => 'OpenIDConnect_State',
         Key  => $StateCSRF,
@@ -376,7 +376,7 @@ sub PreAuth {
 
     # store the RandomString as a CSRF cookie
     $LayoutObject->SetCookie(
-        Key      => 'OIDCCSRF',
+        Key      => 'OIDCCSRF-'.$RandomString,
         Value    => $RandomString,
         Path     => $ConfigObject->Get('ScriptAlias'),
         Secure   => $ConfigObject->Get('HttpType') eq 'https' ? 1 : undef,

--- a/Kernel/System/CustomerAuth/OpenIDConnect.pm
+++ b/Kernel/System/CustomerAuth/OpenIDConnect.pm
@@ -156,7 +156,7 @@ sub Auth {
     # check the state
     my $RandLength = $OpenIDConfig->{Misc}{RandLength} // $Self->{DefaultRandLength};
     my $StateCSRF  = substr $GetParam{State}, 0, $RandLength;
-    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF' );
+    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-'.$StateCSRF );
     my %StateCache = (
         Type => 'OpenIDConnect_State',
         Key  => $StateCSRF,
@@ -287,7 +287,7 @@ sub PreAuth {
 
     # store the RandomString as a CSRF cookie
     $LayoutObject->SetCookie(
-        Key      => 'OIDCCSRF',
+        Key      => 'OIDCCSRF-'.$RandomString,
         Value    => $RandomString,
         Path     => $ConfigObject->Get('ScriptAlias'),
         Secure   => $ConfigObject->Get('HttpType') eq 'https' ? 1 : undef,

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -326,24 +326,13 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
         # login is invalid
         if ( !$User ) {
 
-            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-
-            if ( ref $AuthObject->{AuthBackend} eq 'Kernel::System::Auth::OpenIDConnect' ) {
-
-                # throw a Kernel::System::Web::Exception that redirects
-                $LayoutObject->Redirect(
-                    OP    => "",
-                    Login => 1,
-                );
-                return;
-            }
-
             my $Expires = '+' . $ConfigObject->Get('SessionMaxTime') . 's';
             if ( !$ConfigObject->Get('SessionUseCookieAfterBrowserClose') ) {
                 $Expires = '';
             }
 
             # tentatively set an useless cookie, for checking cookie support
+            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
             $LayoutObject->SetCookie(
                 Key      => 'OTOBOBrowserHasCookie',
                 Value    => 1,
@@ -389,11 +378,11 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
             # show normal login
             return $LayoutObject->Login(
                 Title   => 'Login',
-                Message => $Kernel::OM->Get('Kernel::System::Log')->GetLogEntry(
-                    Type => 'Info',
-                    What => 'Message',
+                Message => $LayoutObject->{LanguageObject}->Translate( $AuthObject->GetLastErrorMessage() )
+                    || $Kernel::OM->Get('Kernel::System::Log')->GetLogEntry(
+                        Type => 'Info',
+                        What => 'Message',
                     )
-                    || $LayoutObject->{LanguageObject}->Translate( $AuthObject->GetLastErrorMessage() )
                     || Translatable('Login failed! Your user name or password was entered incorrectly.'),
                 LoginFailed => 1,
                 MessageType => 'Error',
@@ -627,14 +616,6 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 );    # throws a Kernel::System::Web::Exception
             }
 
-            # try auth module specific logout
-            my $LogoutInfo = $Kernel::OM->Get('Kernel::System::Auth')->Logout();
-            if ( $LogoutInfo && $LogoutInfo->{LogoutURL} ) {
-                $LayoutObject->Redirect(
-                    ExtURL => $LogoutInfo->{LogoutURL},
-                );    # throws a Kernel::System::Web::Exception
-            }
-            
             # show login screen
             return $LayoutObject->Login(
                 Title => 'Logout',

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -326,13 +326,24 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
         # login is invalid
         if ( !$User ) {
 
+            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+            if ( ref $AuthObject->{AuthBackend} eq 'Kernel::System::Auth::OpenIDConnect' ) {
+
+                # throw a Kernel::System::Web::Exception that redirects
+                $LayoutObject->Redirect(
+                    OP    => "",
+                    Login => 1,
+                );
+                return;
+            }
+
             my $Expires = '+' . $ConfigObject->Get('SessionMaxTime') . 's';
             if ( !$ConfigObject->Get('SessionUseCookieAfterBrowserClose') ) {
                 $Expires = '';
             }
 
             # tentatively set an useless cookie, for checking cookie support
-            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
             $LayoutObject->SetCookie(
                 Key      => 'OTOBOBrowserHasCookie',
                 Value    => 1,
@@ -616,6 +627,14 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 );    # throws a Kernel::System::Web::Exception
             }
 
+            # try auth module specific logout
+            my $LogoutInfo = $Kernel::OM->Get('Kernel::System::Auth')->Logout();
+            if ( $LogoutInfo && $LogoutInfo->{LogoutURL} ) {
+                $LayoutObject->Redirect(
+                    ExtURL => $LogoutInfo->{LogoutURL},
+                );    # throws a Kernel::System::Web::Exception
+            }
+            
             # show login screen
             return $LayoutObject->Login(
                 Title => 'Logout',

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -367,23 +367,14 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 }
             }
 
-            if ( ref $AuthObject->{'AuthBackend'} eq 'Kernel::System::CustomerAuth::OpenIDConnect' ) {
-
-                # throw a Kernel::System::Web::Exception that redirects
-                $LayoutObject->Redirect(
-                    OP    => "",
-                    Login => 1,
-                );
-            }
-
             # show normal login
             return $LayoutObject->CustomerLogin(
                 Title   => 'Login',
-                Message => $Kernel::OM->Get('Kernel::System::Log')->GetLogEntry(
-                    Type => 'Info',
-                    What => 'Message',
+                Message => $AuthObject->GetLastErrorMessage()
+                    || $Kernel::OM->Get('Kernel::System::Log')->GetLogEntry(
+                        Type => 'Info',
+                        What => 'Message',
                     )
-                    || $AuthObject->GetLastErrorMessage()
                     || Translatable('Login failed! Your user name or password was entered incorrectly.'),
                 LoginFailed => 1,
                 User        => $PostUser,
@@ -575,14 +566,6 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 $LayoutObject->Redirect(
                     ExtURL => $ConfigObject->Get('CustomerPanelLoginURL')
                         . "?Reason=InvalidSessionID;RequestedURL=$Param{RequestedURL}",
-                );    # throws a Kernel::System::Web::Exception
-            }
-
-            # try auth module specific logout
-            my $LogoutInfo = $Kernel::OM->Get('Kernel::System::CustomerAuth')->Logout();
-            if ( $LogoutInfo && $LogoutInfo->{LogoutURL} ) {
-                $LayoutObject->Redirect(
-                    ExtURL => $LogoutInfo->{LogoutURL},
                 );    # throws a Kernel::System::Web::Exception
             }
 

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -367,6 +367,15 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 }
             }
 
+            if ( ref $AuthObject->{'AuthBackend'} eq 'Kernel::System::CustomerAuth::OpenIDConnect' ) {
+
+                # throw a Kernel::System::Web::Exception that redirects
+                $LayoutObject->Redirect(
+                    OP    => "",
+                    Login => 1,
+                );
+            }
+
             # show normal login
             return $LayoutObject->CustomerLogin(
                 Title   => 'Login',
@@ -566,6 +575,14 @@ sub Content {    ## no critic qw(Subroutines::RequireFinalReturn)
                 $LayoutObject->Redirect(
                     ExtURL => $ConfigObject->Get('CustomerPanelLoginURL')
                         . "?Reason=InvalidSessionID;RequestedURL=$Param{RequestedURL}",
+                );    # throws a Kernel::System::Web::Exception
+            }
+
+            # try auth module specific logout
+            my $LogoutInfo = $Kernel::OM->Get('Kernel::System::CustomerAuth')->Logout();
+            if ( $LogoutInfo && $LogoutInfo->{LogoutURL} ) {
+                $LayoutObject->Redirect(
+                    ExtURL => $LogoutInfo->{LogoutURL},
                 );    # throws a Kernel::System::Web::Exception
             }
 


### PR DESCRIPTION
PR for bugfix in rel-10_1. Do **not** upmerge, dedicated PRs will be made for the higher release branches once this one has completed code-review.

- prevent display of wrong login form _if_ OIDC is enabled
- support multiple tabs for the OIDCCSRF cookie

closes #4393