### PR TITLE
Issue #4476: fix spelling appoitnment => appointment

### DIFF
--- a/Kernel/Language/ar_SA.pm
+++ b/Kernel/Language/ar_SA.pm
@@ -195,7 +195,6 @@ sub Data {
         'Add Notification' => 'إضافة إشعار',
         'Edit Notification' => 'تحرير الإشعار',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'تصدير الإشعارات',
         'Filter for Notifications' => 'فلاتر الإشعارات',
         'Filter for notifications' => 'فلاتر الإشعارات',

--- a/Kernel/Language/bg.pm
+++ b/Kernel/Language/bg.pm
@@ -194,7 +194,6 @@ sub Data {
         'Add Notification' => 'Добавяне на известие',
         'Edit Notification' => 'Редактиране на известие',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Експортиране на известия',
         'Filter for Notifications' => 'Филтър за известия',
         'Filter for notifications' => 'Филтър за известия',

--- a/Kernel/Language/ca.pm
+++ b/Kernel/Language/ca.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Afegir notificació',
         'Edit Notification' => 'Editar notificació',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/cs.pm
+++ b/Kernel/Language/cs.pm
@@ -200,7 +200,6 @@ sub Data {
         'Add Notification' => 'Přidat oznámení',
         'Edit Notification' => 'Upravit oznámení',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportovat oznámení',
         'Filter for Notifications' => 'Filtr pro oznámení',
         'Filter for notifications' => 'Filtr pro oznámení',

--- a/Kernel/Language/da.pm
+++ b/Kernel/Language/da.pm
@@ -194,7 +194,6 @@ sub Data {
         'Add Notification' => 'Tilføj besked',
         'Edit Notification' => 'Rediger besked',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Eksporter beskeder',
         'Filter for Notifications' => 'Filter for Meddelelser',
         'Filter for notifications' => 'Filter for meddelelser',

--- a/Kernel/Language/de.pm
+++ b/Kernel/Language/de.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Benachrichtigung hinzufügen',
         'Edit Notification' => 'Benachrichtigung bearbeiten',
         'Include invalid appointment notifications' => 'Ungültige Terminbenachrichtigungen anzeigen',
-        'Include invalid appoitnment notifications' => 'Ungültige Terminbenachrichtigungen anzeigen',
         'Export Notifications' => 'Benachrichtigungen exportieren',
         'Filter for Notifications' => 'Filter für Benachrichtigungen',
         'Filter for notifications' => 'Filter für Benachrichtigungen',

--- a/Kernel/Language/el.pm
+++ b/Kernel/Language/el.pm
@@ -194,7 +194,6 @@ sub Data {
         'Add Notification' => '',
         'Edit Notification' => '',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/en_CA.pm
+++ b/Kernel/Language/en_CA.pm
@@ -199,7 +199,6 @@ sub Data {
         'Add Notification' => '',
         'Edit Notification' => '',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/en_GB.pm
+++ b/Kernel/Language/en_GB.pm
@@ -196,7 +196,6 @@ sub Data {
         'Add Notification' => 'Add Notification',
         'Edit Notification' => 'Edit Notification',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Export Notifications',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/es.pm
+++ b/Kernel/Language/es.pm
@@ -198,7 +198,6 @@ sub Data {
         'Add Notification' => 'Agregar Notificación',
         'Edit Notification' => 'Editar Notificación',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar Notificaciones',
         'Filter for Notifications' => 'Filtrar por Notificaciones',
         'Filter for notifications' => 'Filtrar por notificaciones',

--- a/Kernel/Language/es_CO.pm
+++ b/Kernel/Language/es_CO.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Agregar Notificación',
         'Edit Notification' => 'Modificar Notificación',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar Notificaciones',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/es_MX.pm
+++ b/Kernel/Language/es_MX.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Agregar Notificación',
         'Edit Notification' => 'Modificar Notificación',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar Notificaciones',
         'Filter for Notifications' => 'Filtro para Notificaciones',
         'Filter for notifications' => 'Filtro para notificaciones',

--- a/Kernel/Language/et.pm
+++ b/Kernel/Language/et.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => '',
         'Edit Notification' => 'Teavituse muutmine',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/fa.pm
+++ b/Kernel/Language/fa.pm
@@ -198,7 +198,6 @@ sub Data {
         'Add Notification' => 'افزودن اعلان',
         'Edit Notification' => 'ویرایش اعلان',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'ارسال اطلاعات',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/fi.pm
+++ b/Kernel/Language/fi.pm
@@ -195,7 +195,6 @@ sub Data {
         'Add Notification' => 'Lisää ilmoitus',
         'Edit Notification' => 'Muokkaa ilmoitusta',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Vie ilmoitukset',
         'Filter for Notifications' => 'Suodata ilmoituksia',
         'Filter for notifications' => 'Suodata ilmoituksia',

--- a/Kernel/Language/fr.pm
+++ b/Kernel/Language/fr.pm
@@ -201,7 +201,6 @@ sub Data {
         'Add Notification' => 'Ajouter une notification',
         'Edit Notification' => 'Editer la notification',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exporter les notifications',
         'Filter for Notifications' => 'Filtre pour les notifications',
         'Filter for notifications' => 'filtre pour les notifications',

--- a/Kernel/Language/fr_CA.pm
+++ b/Kernel/Language/fr_CA.pm
@@ -200,7 +200,6 @@ sub Data {
         'Add Notification' => 'Ajouter une notification',
         'Edit Notification' => 'Éditer une notification',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/gl.pm
+++ b/Kernel/Language/gl.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Engadir unha notificación',
         'Edit Notification' => 'Edite Notificación',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar Notificacións',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/he.pm
+++ b/Kernel/Language/he.pm
@@ -199,7 +199,6 @@ sub Data {
         'Add Notification' => 'הוסף התראה',
         'Edit Notification' => 'ערוך התראה',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/hi.pm
+++ b/Kernel/Language/hi.pm
@@ -195,7 +195,6 @@ sub Data {
         'Add Notification' => 'अधिसूचना जोड़ें',
         'Edit Notification' => 'अधिसूचनाएँ संपादित करें',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/hr.pm
+++ b/Kernel/Language/hr.pm
@@ -197,7 +197,6 @@ sub Data {
         'Add Notification' => 'Dodaj obavijest',
         'Edit Notification' => 'Uredi Obavijest',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Izvezi obavijesti',
         'Filter for Notifications' => 'Filter obavijesti',
         'Filter for notifications' => 'Filter obavjesti',

--- a/Kernel/Language/hu.pm
+++ b/Kernel/Language/hu.pm
@@ -198,7 +198,6 @@ sub Data {
         'Add Notification' => 'Értesítés hozzáadása',
         'Edit Notification' => 'Értesítés szerkesztése',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Értesítések exportálása',
         'Filter for Notifications' => 'Szűrő az értesítésekhez',
         'Filter for notifications' => 'Szűrő az értesítésekhez',

--- a/Kernel/Language/id.pm
+++ b/Kernel/Language/id.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Tambah pemberitahuan',
         'Edit Notification' => 'Ubah pemberitahuan',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Expor pemberitahuan',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/it.pm
+++ b/Kernel/Language/it.pm
@@ -201,7 +201,6 @@ sub Data {
         'Add Notification' => 'Aggiungi notifica',
         'Edit Notification' => 'Modifica notifica',
         'Include invalid appointment notifications' => 'Includi notifiche di appuntamenti non validi',
-        'Include invalid appoitnment notifications' => 'Includi notifiche di appuntamenti non validi',
         'Export Notifications' => 'Esportazione notifiche',
         'Filter for Notifications' => 'Filtro per notifiche',
         'Filter for notifications' => 'Filtro per notifiche',

--- a/Kernel/Language/ja.pm
+++ b/Kernel/Language/ja.pm
@@ -196,7 +196,6 @@ sub Data {
         'Add Notification' => '通知の追加',
         'Edit Notification' => '通知の編集',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '通知をエクスポート',
         'Filter for Notifications' => '通知でフィルター',
         'Filter for notifications' => '通知でフィルター',

--- a/Kernel/Language/ko.pm
+++ b/Kernel/Language/ko.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => '알림 추가',
         'Edit Notification' => '알림 수정',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '알림 Export',
         'Filter for Notifications' => '알림 필터',
         'Filter for notifications' => '알림 필터',

--- a/Kernel/Language/lt.pm
+++ b/Kernel/Language/lt.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Pridėti pranešimą',
         'Edit Notification' => 'Redaguoti pranešimus',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Eksportuoti pranešimus',
         'Filter for Notifications' => 'Filtruoti pranešimus',
         'Filter for notifications' => 'Filtruoti pranešimus',

--- a/Kernel/Language/lv.pm
+++ b/Kernel/Language/lv.pm
@@ -192,7 +192,6 @@ sub Data {
         'Add Notification' => 'Pievienot paziņojumu',
         'Edit Notification' => 'Labot paziņojumu',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/mk.pm
+++ b/Kernel/Language/mk.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Додај Известување',
         'Edit Notification' => 'Уреди го Известувањето',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/ms.pm
+++ b/Kernel/Language/ms.pm
@@ -192,7 +192,6 @@ sub Data {
         'Add Notification' => 'Tambah pemberitahuan',
         'Edit Notification' => 'Edit pemberitahuan',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Eksport pemberitahuan',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/nb_NO.pm
+++ b/Kernel/Language/nb_NO.pm
@@ -201,7 +201,6 @@ sub Data {
         'Add Notification' => 'Legg til varsling',
         'Edit Notification' => 'Endre varsling',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Eksporter varslinger',
         'Filter for Notifications' => 'Filter for varslinger',
         'Filter for notifications' => 'Filter for varslinger',

--- a/Kernel/Language/nl.pm
+++ b/Kernel/Language/nl.pm
@@ -199,7 +199,6 @@ sub Data {
         'Add Notification' => 'Melding toevoegen',
         'Edit Notification' => 'Bewerk melding',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Meldingen exporteren',
         'Filter for Notifications' => 'Filter voor notificaties',
         'Filter for notifications' => 'Filter voor notificaties',

--- a/Kernel/Language/pl.pm
+++ b/Kernel/Language/pl.pm
@@ -196,7 +196,6 @@ sub Data {
         'Add Notification' => 'Dodaj powiadomienie',
         'Edit Notification' => 'Edytuj Powiadomienie',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Eksportuj powiadomienia',
         'Filter for Notifications' => 'Filtr powiadomień',
         'Filter for notifications' => 'Filtr powiadomień',

--- a/Kernel/Language/pt.pm
+++ b/Kernel/Language/pt.pm
@@ -194,7 +194,6 @@ sub Data {
         'Add Notification' => 'Adicionar notificação',
         'Edit Notification' => 'Editar notificação',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar Notificações',
         'Filter for Notifications' => 'Filtro para Notificações',
         'Filter for notifications' => 'Filtro para Notificações',

--- a/Kernel/Language/pt_BR.pm
+++ b/Kernel/Language/pt_BR.pm
@@ -198,7 +198,6 @@ sub Data {
         'Add Notification' => 'Adicionar Notificação',
         'Edit Notification' => 'Alterar Notificação',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportar notificações',
         'Filter for Notifications' => 'Filtro para Notificações',
         'Filter for notifications' => 'Filtro para notificações',

--- a/Kernel/Language/ro.pm
+++ b/Kernel/Language/ro.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Adaugă Notificare',
         'Edit Notification' => 'Modifică Notificarea',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportă Notificările',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/ru.pm
+++ b/Kernel/Language/ru.pm
@@ -204,7 +204,6 @@ sub Data {
         'Add Notification' => 'Добавить уведомление',
         'Edit Notification' => 'Изменить уведомление',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Экспортировать уведомления',
         'Filter for Notifications' => 'Фильтр для уведомлений',
         'Filter for notifications' => 'Фильтр для уведомлений',

--- a/Kernel/Language/sk_SK.pm
+++ b/Kernel/Language/sk_SK.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Pridaj notifikáciu',
         'Edit Notification' => 'Edituj notifikáciu',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Export notifikácií',
         'Filter for Notifications' => 'Filter pre notifikácie',
         'Filter for notifications' => 'Filter pre notifikácie',

--- a/Kernel/Language/sl.pm
+++ b/Kernel/Language/sl.pm
@@ -197,7 +197,6 @@ sub Data {
         'Add Notification' => 'Dodaj obvestilo',
         'Edit Notification' => 'Uredi obvestilo',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Izvozi obvestila',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/sr_Cyrl.pm
+++ b/Kernel/Language/sr_Cyrl.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Додај Обавештење',
         'Edit Notification' => 'Уреди обавештење',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Обавештења о извозу',
         'Filter for Notifications' => 'Филтер за обавештења',
         'Filter for notifications' => 'Филтер за обавештења',

--- a/Kernel/Language/sr_Latn.pm
+++ b/Kernel/Language/sr_Latn.pm
@@ -199,7 +199,6 @@ sub Data {
         'Add Notification' => 'Dodaj Obaveštenje',
         'Edit Notification' => 'Uredi obaveštenje',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Obaveštenja o izvozu',
         'Filter for Notifications' => 'Filter za obaveštenja',
         'Filter for notifications' => 'Filter za obaveštenja',

--- a/Kernel/Language/sv.pm
+++ b/Kernel/Language/sv.pm
@@ -195,7 +195,6 @@ sub Data {
         'Add Notification' => 'Lägg till Meddelande',
         'Edit Notification' => 'Redigera notifiering',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Exportmeddelanden',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/sw.pm
+++ b/Kernel/Language/sw.pm
@@ -196,7 +196,6 @@ sub Data {
         'Add Notification' => 'Ongeza taarifa',
         'Edit Notification' => 'Hariri taarifa',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/th_TH.pm
+++ b/Kernel/Language/th_TH.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'เพิ่มการแจ้งเตือน',
         'Edit Notification' => 'แก้ไขการแจ้งเตือน',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'ส่งออกการแจ้งเตือน',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/tr.pm
+++ b/Kernel/Language/tr.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Bildirim ekle',
         'Edit Notification' => 'Bildirim Düzenle',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => 'Bildirimler İçin Filtreleme',
         'Filter for notifications' => 'Bildirimler için filtreleme',

--- a/Kernel/Language/uk.pm
+++ b/Kernel/Language/uk.pm
@@ -193,7 +193,6 @@ sub Data {
         'Add Notification' => 'Додати повідомлення',
         'Edit Notification' => 'Редагувати повідомлення',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => 'Експортувати Сповіщень',
         'Filter for Notifications' => 'Фільтр сповіщень',
         'Filter for notifications' => 'Фільтр для сповіщень',

--- a/Kernel/Language/vi_VN.pm
+++ b/Kernel/Language/vi_VN.pm
@@ -192,7 +192,6 @@ sub Data {
         'Add Notification' => '',
         'Edit Notification' => '',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Language/zh_CN.pm
+++ b/Kernel/Language/zh_CN.pm
@@ -199,7 +199,6 @@ sub Data {
         'Add Notification' => '添加通知',
         'Edit Notification' => '编辑通知',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '导出通知',
         'Filter for Notifications' => '通知过滤器',
         'Filter for notifications' => '通知过滤器',

--- a/Kernel/Language/zh_TW.pm
+++ b/Kernel/Language/zh_TW.pm
@@ -195,7 +195,6 @@ sub Data {
         'Add Notification' => '添加通知',
         'Edit Notification' => '編輯通知',
         'Include invalid appointment notifications' => '',
-        'Include invalid appoitnment notifications' => '',
         'Export Notifications' => '導出通知',
         'Filter for Notifications' => '',
         'Filter for notifications' => '',

--- a/Kernel/Output/HTML/Templates/Standard/AdminAppointmentNotificationEvent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAppointmentNotificationEvent.tt
@@ -47,7 +47,7 @@
             </div>
             <div class="Content">
                 <input type="checkbox" id="IncludeInvalid" name="IncludeInvalid" value="1" title="[% Translate("Include invalid appointment notifications") | html %]" [% Data.IncludeInvalidChecked | html %]/>
-                <label for="IncludeInvalid">[% Translate("Include invalid appoitnment notifications") | html %]</label>
+                <label for="IncludeInvalid">[% Translate("Include invalid appointment notifications") | html %]</label>
             </div>
         </div>
 [% RenderBlockEnd("IncludeInvalid") %]

--- a/i18n/otobo/otobo.ar_SA.po
+++ b/i18n/otobo/otobo.ar_SA.po
@@ -25562,10 +25562,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.bg.po
+++ b/i18n/otobo/otobo.bg.po
@@ -25587,10 +25587,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.ca.po
+++ b/i18n/otobo/otobo.ca.po
@@ -25532,10 +25532,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.cs.po
+++ b/i18n/otobo/otobo.cs.po
@@ -25620,10 +25620,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.da.po
+++ b/i18n/otobo/otobo.da.po
@@ -25727,10 +25727,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.de.po
+++ b/i18n/otobo/otobo.de.po
@@ -26284,10 +26284,6 @@ msgstr "Ungültige Kalender anzeigen"
 msgid "Include invalid appointment notifications"
 msgstr "Ungültige Terminbenachrichtigungen anzeigen"
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr "Ungültige Terminbenachrichtigungen anzeigen"
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr "Ungültige Anhänge anzeigen"

--- a/i18n/otobo/otobo.el.po
+++ b/i18n/otobo/otobo.el.po
@@ -25567,10 +25567,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.en_CA.po
+++ b/i18n/otobo/otobo.en_CA.po
@@ -25500,10 +25500,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.en_GB.po
+++ b/i18n/otobo/otobo.en_GB.po
@@ -25877,10 +25877,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.es.po
+++ b/i18n/otobo/otobo.es.po
@@ -25954,10 +25954,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.es_CO.po
+++ b/i18n/otobo/otobo.es_CO.po
@@ -25567,10 +25567,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.es_MX.po
+++ b/i18n/otobo/otobo.es_MX.po
@@ -25817,10 +25817,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.et.po
+++ b/i18n/otobo/otobo.et.po
@@ -25539,10 +25539,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.fa.po
+++ b/i18n/otobo/otobo.fa.po
@@ -25893,10 +25893,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.fi.po
+++ b/i18n/otobo/otobo.fi.po
@@ -25534,10 +25534,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.fr.po
+++ b/i18n/otobo/otobo.fr.po
@@ -25811,10 +25811,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.fr_CA.po
+++ b/i18n/otobo/otobo.fr_CA.po
@@ -25560,10 +25560,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.gl.po
+++ b/i18n/otobo/otobo.gl.po
@@ -25781,10 +25781,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.he.po
+++ b/i18n/otobo/otobo.he.po
@@ -25540,10 +25540,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.hi.po
+++ b/i18n/otobo/otobo.hi.po
@@ -25530,10 +25530,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.hr.po
+++ b/i18n/otobo/otobo.hr.po
@@ -25524,10 +25524,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.hu.po
+++ b/i18n/otobo/otobo.hu.po
@@ -26118,10 +26118,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.id.po
+++ b/i18n/otobo/otobo.id.po
@@ -25895,10 +25895,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.it.po
+++ b/i18n/otobo/otobo.it.po
@@ -25945,10 +25945,6 @@ msgstr "Includi calendari non validi"
 msgid "Include invalid appointment notifications"
 msgstr "Includi notifiche di appuntamenti non validi"
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr "Includi notifiche di appuntamenti non validi"
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr "Includi allegati non validi"

--- a/i18n/otobo/otobo.ja.po
+++ b/i18n/otobo/otobo.ja.po
@@ -25961,10 +25961,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.ko.po
+++ b/i18n/otobo/otobo.ko.po
@@ -26053,10 +26053,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.lt.po
+++ b/i18n/otobo/otobo.lt.po
@@ -25523,10 +25523,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.lv.po
+++ b/i18n/otobo/otobo.lv.po
@@ -25563,10 +25563,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.mk.po
+++ b/i18n/otobo/otobo.mk.po
@@ -25719,10 +25719,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.ms.po
+++ b/i18n/otobo/otobo.ms.po
@@ -25860,10 +25860,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.nb_NO.po
+++ b/i18n/otobo/otobo.nb_NO.po
@@ -25709,10 +25709,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.nl.po
+++ b/i18n/otobo/otobo.nl.po
@@ -25855,10 +25855,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.pl.po
+++ b/i18n/otobo/otobo.pl.po
@@ -25858,10 +25858,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.pot
+++ b/i18n/otobo/otobo.pot
@@ -491,10 +491,6 @@ msgid "Include invalid appointment notifications"
 msgstr ""
 
 #. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
-#. Template: AdminAppointmentNotificationEvent
 msgid "Export Notifications"
 msgstr ""
 

--- a/i18n/otobo/otobo.pt.po
+++ b/i18n/otobo/otobo.pt.po
@@ -25628,10 +25628,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.pt_BR.po
+++ b/i18n/otobo/otobo.pt_BR.po
@@ -26133,10 +26133,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.ro.po
+++ b/i18n/otobo/otobo.ro.po
@@ -25664,10 +25664,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.ru.po
+++ b/i18n/otobo/otobo.ru.po
@@ -26107,10 +26107,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.sk_SK.po
+++ b/i18n/otobo/otobo.sk_SK.po
@@ -25576,10 +25576,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.sl.po
+++ b/i18n/otobo/otobo.sl.po
@@ -25531,10 +25531,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.sr.po
+++ b/i18n/otobo/otobo.sr.po
@@ -26118,10 +26118,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.sv.po
+++ b/i18n/otobo/otobo.sv.po
@@ -25673,10 +25673,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.sw.po
+++ b/i18n/otobo/otobo.sw.po
@@ -25771,10 +25771,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.th_TH.po
+++ b/i18n/otobo/otobo.th_TH.po
@@ -25833,10 +25833,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.tr.po
+++ b/i18n/otobo/otobo.tr.po
@@ -25528,10 +25528,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.uk.po
+++ b/i18n/otobo/otobo.uk.po
@@ -25797,10 +25797,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.vi_VN.po
+++ b/i18n/otobo/otobo.vi_VN.po
@@ -25557,10 +25557,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.zh_CN.po
+++ b/i18n/otobo/otobo.zh_CN.po
@@ -26211,10 +26211,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""

--- a/i18n/otobo/otobo.zh_TW.po
+++ b/i18n/otobo/otobo.zh_TW.po
@@ -25606,10 +25606,6 @@ msgstr ""
 msgid "Include invalid appointment notifications"
 msgstr ""
 
-#. Template: AdminAppointmentNotificationEvent
-msgid "Include invalid appoitnment notifications"
-msgstr ""
-
 #. Template: AdminAttachment
 msgid "Include invalid attachments"
 msgstr ""


### PR DESCRIPTION
the correct spelling was already in the translation files. So only the invalid string was removed from the translation files.