### PR TITLE
Issue #4486: add git as a dependency

### DIFF
--- a/otobo.web.dockerfile
+++ b/otobo.web.dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update\
  "ack"\
  "cron"\
  "default-mysql-client"\
+ "git"\
  "ldap-utils"\
  "less"\
  "nano"\


### PR DESCRIPTION
actually git is already included in the regular Debian image. However, the explicit declaration is needed when moving to slim Debian images