### PR TITLE
Issue #4526: fix precedence issue problem

### DIFF
--- a/Kernel/Modules/AdminImportExport.pm
+++ b/Kernel/Modules/AdminImportExport.pm
@@ -261,10 +261,9 @@ sub Run {
                 if (
                     $Item->{Input}->{Regex}
                     &&
-                    !$AttributeValues{ $Item->{Key} } =~ $Item->{Input}->{Regex}
+                    $AttributeValues{ $Item->{Key} } !~ $Item->{Input}->{Regex}
                     )
                 {
-
                     $DataTypeError{ $Item->{Name} } = 1;
                     $Error = 1;
                 }


### PR DESCRIPTION
the intent of the code is obvious. An error should be indicated when the ImportExport attribute is limited by a regex and the regex does not match. In the present implementation the check is not done on the intended value. This is a bug which is fixed in this commit.

The bug was not really noticed until now because using Regexes for declaring ImportExport attributes is rarely needed. Neither the export of translations nor the package ImportExportTicket uses that feature.