### PR TITLE
Issue #4526: explicitly state the intended precedence

### DIFF
--- a/Kernel/System/Ticket/Mask.pm
+++ b/Kernel/System/Ticket/Mask.pm
@@ -303,7 +303,7 @@ sub _DefinitionDynamicFieldGet {
             return {
                 Success => 0,
                 Error   => sprintf( Translatable('Dynamic field "%s" not valid.'), $Name ),
-            } if !$DynamicField->{ValidID} eq '1';
+            } if ( !$DynamicField->{ValidID} ) eq '1';
 
             return {
                 Success => 0,


### PR DESCRIPTION
Perl 5.42 added new warnings about possible precedence problems. In this case the precedence was as intended. Added parens for explicitly indicating the intended precedence. This silences the warning.