### PR TITLE
Fix "Use of uninitialized value $File in concatenation ..." during package build.

### DIFF
--- a/Kernel/System/Console/Command/Dev/Package/Build.pm
+++ b/Kernel/System/Console/Command/Dev/Package/Build.pm
@@ -125,20 +125,21 @@ sub Run {
     }
 
     my $Filename = $Structure{Name}->{Content} . '-' . $Structure{Version}->{Content} . '.opm';
+    my $Location = $Self->GetArgument('target-directory') . '/' . $Filename;
     my $Content  = $Kernel::OM->Get('Kernel::System::Package')->PackageBuild(%Structure);
     if ( !$Content ) {
         $Self->PrintError("Package build failed.\n");
         return $Self->ExitCodeError();
     }
     my $File = $Kernel::OM->Get('Kernel::System::Main')->FileWrite(
-        Location   => $Self->GetArgument('target-directory') . '/' . $Filename,
+        Location   => $Location,
         Content    => \$Content,
         Mode       => 'utf8',                                                     # binmode|utf8
         Type       => 'Local',                                                    # optional - Local|Attachment|MD5
         Permission => '644',                                                      # unix file permissions
     );
     if ( !$File ) {
-        $Self->PrintError("File $Filename could not be written.\n");
+        $Self->PrintError("File $Location could not be written.\n");
         return $Self->ExitCodeError();
     }
 

--- a/Kernel/System/Console/Command/Dev/Package/Build.pm
+++ b/Kernel/System/Console/Command/Dev/Package/Build.pm
@@ -138,7 +138,7 @@ sub Run {
         Permission => '644',                                                      # unix file permissions
     );
     if ( !$File ) {
-        $Self->PrintError("File $File could not be written.\n");
+        $Self->PrintError("File $Filename could not be written.\n");
         return $Self->ExitCodeError();
     }
 


### PR DESCRIPTION
The pull request contains a small fix for "Use of uninitialized value $File in concatenation (.) or string at /opt/otobo/Kernel/System/Console/Command/Dev/Package/Build.pm line 141."

This problem occurs when running `/opt/otobo/bin/otobo.Console.pl Dev::Package::Build SomePackage.sopm ./build` if the destination directory is not writeable.

The empty variable `$File` is used instead of `$Filename`

File: Kernel/System/Console/Command/Dev/Package/Build.pm
```perl
    if ( !$File ) {
        $Self->PrintError("File $File could not be written.\n");
        return $Self->ExitCodeError();
    }
```

GitHub workflow log: (https://github.com/Micke90s/OTOBO-Example-Agent-Skin)
``` 
ERROR: OTOBO-otobo.Console.pl-Dev::Package::Build-10 Perl: 5.38.4 OS: linux Time: Fri Aug  8 22:22:27 2025
 Message: Can't write './build/ExampleAgentSkin-0.0.25.opm': 
 Traceback (150): 
   Module: Kernel::System::Main::FileWrite Line: 587
   Module: Kernel::System::Console::Command::Dev::Package::Build::Run Line: 133
   Module: (eval) Line: 488
   Module: Kernel::System::Console::BaseCommand::Execute Line: 482
   Module: Kernel::System::Console::InterfaceConsole::Run Line: 88
   Module: /opt/otobo/bin/otobo.Console.pl Line: 40
Use of uninitialized value $File in concatenation (.) or string at /opt/otobo/Kernel/System/Console/Command/Dev/Package/Build.pm line 141.
Error: File  could not be written.
Building package...
Error: Process completed with exit code 1.
```

