### PR TITLE
Issue #4451: use the base image perl:5.40-slim-trixie

### DIFF
--- a/otobo.web.dockerfile
+++ b/otobo.web.dockerfile
@@ -21,7 +21,7 @@
 # The slim version is used for reducing the size of the image.
 #
 # The individual build targets may add additional Debian or CPAN packages.
-FROM perl:5.42-slim-bookworm AS base
+FROM perl:5.40-slim-trixie AS base
 
 # First there is some initial setup that needs to be done by root.
 USER root
@@ -68,7 +68,7 @@ RUN apt-get update\
  "ldap-utils"\
  "less"\
  "nano"\
- "odbcinst1debian2" "libodbc1" "odbcinst" "unixodbc-dev" "unixodbc"\
+ "unixodbc-common" "libodbcinst2" "libodbccr2" "libodbc2" "odbcinst" "unixodbc-dev" "unixodbc"\
  "freetds-bin" "freetds-common" "tdsodbc"\
  "postgresql-client"\
  "redis-tools"\


### PR DESCRIPTION
Update the Debian packages needed for ODBC support, because some of the packages have been renamed.