### PR TITLE
Issue #4570: exit early when the backup dir is within /opt/otobo

### DIFF
--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -218,15 +218,24 @@ else {
     }
 }
 
+# make BackupDir absolute
+$BackupDir = abs_path($BackupDir);
+
 # create new backup directory
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
+
+# make sure backup dir is not under OTOBO_HOME (usually /opt/otobo)
+if( $BackupDir =~ /^$Home/ ) {
+
+    say STDERR ("Backup directory '$BackupDir' is under '$Home', please chose a different backup directory not below the otobo home directory with the -d option!");
+    exit 1;
+}
 
 # append trailing slash to home directory, if it's missing
 if ( $Home !~ m{\/\z} ) {
     $Home .= '/';
 }
 
-$BackupDir = abs_path($BackupDir);
 chdir($Home);
 
 # current time needed for the backup-dir and for removing old backups


### PR DESCRIPTION
this is basically the version for rel-10_0, but please merge upwards anyway.

for rel-10_1 upwards where Class::Path is avail another PR will be made using https://metacpan.org/pod/Path::Class::Dir#$boolean-=-$dir-%3Econtains($other)  