### PR TITLE
Issue #4606: interpolate links in set-inner DFs

### DIFF
--- a/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
+++ b/Kernel/Output/HTML/TicketZoom/TicketInformation.pm
@@ -424,6 +424,7 @@ sub Run {
             Value              => $Ticket{"DynamicField_$DynamicFieldConfig->{Name}"},
             LayoutObject       => $LayoutObject,
             ValueMaxChars      => $ConfigObject->Get('Ticket::Frontend::DynamicFieldsZoomMaxSizeSidebar') || 18,    # limit for sidebar display
+            Ticket             => \%Ticket,
         );
 
         if ( $Self->{DisplaySettings}->{DynamicField}->{ $DynamicFieldConfig->{Name} } ) {

--- a/Kernel/System/DynamicField/Driver/Set.pm
+++ b/Kernel/System/DynamicField/Driver/Set.pm
@@ -601,8 +601,34 @@ sub DisplayValueRender {
 
             if ($HTMLOutput) {
                 if ( $Element->{Link} ) {
+
+                    # Link might contain Template Toolkit expressions,
+                    # so we have to interpolate
+                    my $Link = $Element->{Link};
+
+                    # if ticket info was passed as argument, add it to
+                    # interpolation dataset
+                    my $Ticket = $Param{Ticket} || {};
+
+                    my $Data = {
+                        $Ticket->%*,
+                        $Name => $Element->{Value},
+
+                        # alias for ticket title, Title will be overwritten
+                        TicketTitle          => $Ticket->{Title} // '',
+                        Value                => $Element->{Value},
+                        Title                => $Element->{Title},
+                        Link                 => $Element->{Link},
+                        "DynamicField_$Name" => $Element->{Value},
+                    };
+
+                    my $LinkInterpolated = $Param{LayoutObject}->Output(
+                        Template => $Link,
+                        Data     => $Data
+                    );
+
                     $SetValue{Value}[$SetIndex]
-                        .= "<label>$Label</label><p class=\"Value\"><a href=\"$Element->{Link}\" title=\"$Element->{Title}\">$Element->{Value}</a></p><div class=\"Clear\"></div>";
+                        .= "<label>$Label</label><p class=\"Value\"><a href=\"$LinkInterpolated\" title=\"$Element->{Title}\">$Element->{Value}</a></p><div class=\"Clear\"></div>";
                 }
                 else {
                     $SetValue{Value}[$SetIndex]


### PR DESCRIPTION
first attempt to resolve this issue.

Basically, since $Element->{Link} might contain Template Toolkit expression(s), we need to interpolate before construction the HTML. so far so good.

remaining issue is the fact that for this to succeed in all scenarios the help text for advertises in the DF UI, we need more data as the link cannot only reference the DF itself, but also other DFs in the Ticket containing the DF.

For the TicketInformation Widget int AgentTicketZoom, this can be solved by passing the Ticket data along in the call to DisplayValueRender(), and that seems to work nicely.

@svenoe  
Worried a bit if there are other known places besides AgentTicketZoom where passing additional data would also be necessary for the full feature set?

