### PR TITLE
Issue #4570: use Path::Class to check if backupdir is below OTOBO_HOME

### DIFF
--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -30,7 +30,7 @@ use Getopt::Long qw(GetOptions);
 use Cwd          qw(abs_path getcwd);
 
 # CPAN modules
-use Path::Class;
+use Path::Class qw(dir);
 
 # OTOBO modules
 use Kernel::System::ObjectManager;

--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -30,6 +30,7 @@ use Getopt::Long qw(GetOptions);
 use Cwd          qw(abs_path getcwd);
 
 # CPAN modules
+use Path::Class;
 
 # OTOBO modules
 use Kernel::System::ObjectManager;
@@ -225,7 +226,7 @@ $BackupDir = abs_path($BackupDir);
 my $Home = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
 # make sure backup dir is not under OTOBO_HOME (usually /opt/otobo)
-if ( $BackupDir =~ /^$Home/ ) {
+if( dir($Home)->contains($BackupDir) ) {
 
     say STDERR ("Backup directory '$BackupDir' is under '$Home', please chose a different backup directory not below the OTOBO home directory with the -d option!");
     exit 1;


### PR DESCRIPTION
closes #4570 

this is the version for rel-10_1 upwards, where Path::Class is available