### PR TITLE
Issue #4130: avoid setTimeout when calling InitFavourites() after AJAX call

### DIFF
--- a/var/httpd/htdocs/js/Core.SystemConfiguration.js
+++ b/var/httpd/htdocs/js/Core.SystemConfiguration.js
@@ -1714,12 +1714,11 @@ var Core = Core || {};
                         Counter++;
                     },
                 });
+
+                Core.Agent.Admin.SystemConfiguration.InitFavourites();
+
             }, 'html'
         );
-
-        window.setTimeout(function() {
-            Core.Agent.Admin.SystemConfiguration.InitFavourites();
-        }, 1000);
     }
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');


### PR DESCRIPTION
closes #4130 

