### PR TITLE
redirect feature requests to ideas.otobo.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: true
+contact_links:
+  - name: Feature Request
+    url: https://ideas.otobo.io
+    about: Propose a new feature or an improvement to an existing feature and help shape the future of OTOBO (external).


### PR DESCRIPTION
This adds a link for Feature Requests to ideas.otobo.io.
1. Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
2. Showcase: https://github.com/73/super-duper-fiesta/issues/new/choose