### PR TITLE
Issue #4701: no longe pass 'mysql_auto_reconnect = 0'

### DIFF
--- a/Kernel/System/DB/mysql.pm
+++ b/Kernel/System/DB/mysql.pm
@@ -74,12 +74,9 @@ sub LoadPreferences {
     # this is primarily needed during migration
     $Self->{'DB::Substring'} = 'SUBSTRING(%s, %s, %s)';
 
-    # DBI/DBD::mysql attributes
-    # disable automatic reconnects as they do not execute DB::Connect, which will
-    # cause charset problems
-    $Self->{'DB::Attribute'} = {
-        mysql_auto_reconnect => 0,
-    };
+    # DBI/DBD::mysql attributes. These will be passed when connecting to the database.
+    # Note that "mysql_auto_reconnect => 0" is set by DBIx::Connector::Driver::mysql.
+    $Self->{'DB::Attribute'} = {};
 
     # set current time stamp if different to "current_timestamp"
     $Self->{'DB::CurrentTimestamp'} = '';


### PR DESCRIPTION
when connecting to MySQL or MariaDB. But note that the same setting is supplied by DBIx::Connector. Thus there is no change in the actual connection parameters.