### PR TITLE
Issue #2297: discard objects in $Kernel::OM before global destruction

### DIFF
--- a/Kernel/System/Log.pm
+++ b/Kernel/System/Log.pm
@@ -212,20 +212,11 @@ sub Log {
     # if error, write it to STDERR
     if ( $Priority =~ m/^error/i ) {
 
-        my $Error;
-        if ( ${^GLOBAL_PHASE} eq 'DESTRUCT' ) {
-            $Error = sprintf 'ERROR: %s OS: %s Time: %s (in global destruction)',
-                $Self->{LogPrefix},    # from constructor argument
-                $^O,                   # $OSNAME, the operating system
-                $LogTime;              # a string with the current date and time
-        }
-        else {
-            $Error = sprintf 'ERROR: %s Perl: %vd OS: %s Time: %s',
-                $Self->{LogPrefix},    # from constructor argument
-                $^V,                   # $PERL_VERSION, the Perl version object
-                $^O,                   # $OSNAME, the operating system
-                $LogTime;              # a string with the current date and time
-        }
+        my $Error = sprintf 'ERROR: %s Perl: %vd OS: %s Time: %s',
+            $Self->{LogPrefix},    # from constructor argument
+            $^V,                   # $PERL_VERSION, the Perl version object
+            $^O,                   # $OSNAME, the operating system
+            $LogTime;              # a string with the current date and time
         $Error .= "\n\n";
         $Error .= " Message: $Message\n\n";
 

--- a/Kernel/System/UnitTest/RegisterOM.pm
+++ b/Kernel/System/UnitTest/RegisterOM.pm
@@ -70,4 +70,14 @@ sub import {    ## no critic qw(OTOBO::RequireCamelCase)
     return;
 }
 
+END {
+
+    # Clean up the global objects before global destruction sets in.
+    # This makes the test scripts behave more like otobo.psgi
+    # or otobo.Console.pl .
+    if ($Kernel::OM) {
+        $Kernel::OM->ObjectsDiscard;
+    }
+}
+
 1;


### PR DESCRIPTION
The is done by registering an END handler in K::S::UnitTest::RegisterOM. This lets the test scripts behave more like the other OTOBO code.

Thus the special check, regarding 5^V, is no longer necessary in K::S::Log.