### PR TITLE
Let CodePolicy tidy things up a bit.

### DIFF
--- a/Kernel/Modules/CustomerDashboardContent.pm
+++ b/Kernel/Modules/CustomerDashboardContent.pm
@@ -97,7 +97,7 @@ sub Run {
         my $Content = $HTMLUtilsObject->DocumentComplete(
             String            => $InfoTileContent,
             CustomerInterface => 1,
-            CustomerUIStyles => 1,
+            CustomerUIStyles  => 1,
         );
 
         return $LayoutObject->Attachment(

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -3946,7 +3946,7 @@ sub BuildDateSelection {
     );
 
     # Add Datepicker JS to output if we are not rendering a multivalue template.
-    if ( $Prefix !~ /^DynamicField_/ || ($Suffix ne '_Template' && $Prefix !~ /_Template$/)) {
+    if ( $Prefix !~ /^DynamicField_/ || ( $Suffix ne '_Template' && $Prefix !~ /_Template$/ ) ) {
         my $DatepickerJS = '
         Core.UI.Datepicker.Init({
             Day: $("#" + Core.App.EscapeSelector("' . $Prefix . '") + "Day"' .       ( $Suffix ? ' + Core.App.EscapeSelector("' . $Suffix . '")' : '' ) . '),

--- a/Kernel/System/Auth/OpenIDConnect.pm
+++ b/Kernel/System/Auth/OpenIDConnect.pm
@@ -156,7 +156,7 @@ sub Auth {
     # check the state
     my $RandLength = $OpenIDConfig->{Misc}{RandLength} // $Self->{DefaultRandLength};
     my $StateCSRF  = substr $GetParam{State}, 0, $RandLength;
-    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-'.$StateCSRF );
+    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-' . $StateCSRF );
     my %StateCache = (
         Type => 'OpenIDConnect_State',
         Key  => $StateCSRF,
@@ -377,7 +377,7 @@ sub PreAuth {
 
     # store the RandomString as a CSRF cookie
     $LayoutObject->SetCookie(
-        Key     => 'OIDCCSRF-'.$RandomString,
+        Key     => 'OIDCCSRF-' . $RandomString,
         Value   => $RandomString,
         Expires => '+' . $TTL . 's',
     );

--- a/Kernel/System/Console/Command/Dev/Package/Build.pm
+++ b/Kernel/System/Console/Command/Dev/Package/Build.pm
@@ -134,9 +134,9 @@ sub Run {
     my $File = $Kernel::OM->Get('Kernel::System::Main')->FileWrite(
         Location   => $Location,
         Content    => \$Content,
-        Mode       => 'utf8',                                                     # binmode|utf8
-        Type       => 'Local',                                                    # optional - Local|Attachment|MD5
-        Permission => '644',                                                      # unix file permissions
+        Mode       => 'utf8',      # binmode|utf8
+        Type       => 'Local',     # optional - Local|Attachment|MD5
+        Permission => '644',       # unix file permissions
     );
     if ( !$File ) {
         $Self->PrintError("File $Location could not be written.\n");

--- a/Kernel/System/CustomerAuth/OpenIDConnect.pm
+++ b/Kernel/System/CustomerAuth/OpenIDConnect.pm
@@ -157,7 +157,7 @@ sub Auth {
     # check the state
     my $RandLength = $OpenIDConfig->{Misc}{RandLength} // $Self->{DefaultRandLength};
     my $StateCSRF  = substr $GetParam{State}, 0, $RandLength;
-    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-'.$StateCSRF );
+    my $CookieCSRF = $ParamObject->GetCookie( Key => 'OIDCCSRF-' . $StateCSRF );
     my %StateCache = (
         Type => 'OpenIDConnect_State',
         Key  => $StateCSRF,
@@ -288,7 +288,7 @@ sub PreAuth {
 
     # store the RandomString as a CSRF cookie
     $LayoutObject->SetCookie(
-        Key     => 'OIDCCSRF-'.$RandomString,
+        Key     => 'OIDCCSRF-' . $RandomString,
         Value   => $RandomString,
         Expires => '+' . $TTL . 's',
     );


### PR DESCRIPTION
The changes contain minor tidying made by CodePolicy. Despite it being only cosmetic changes, I consider it a nice thing to have code consistently.

I ran the CodePolicy on large parts of `Kernel/` because I wanted to get a feeling on how many violations of `ProhibitUnusedVarsStricter` are still left and the changes here are the fallout of this.