### PR TITLE
Issue #4572: use libpcre2 instead of libpcre3

### DIFF
--- a/otobo.nginx-kerberos.dockerfile
+++ b/otobo.nginx-kerberos.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update\
         gcc \
         libc-dev \
         make \
-        libpcre3-dev \
+        libpcre2-dev \
         zlib1g-dev \
         libkrb5-dev \
         wget


### PR DESCRIPTION
This is because nginx:mainline switched to Debian 13 Trixie. And Trixie no longer ships libpcre3, only the newer libpcre2. Yes, libpcre2 is newer than libpcre3