### PR TITLE
Issue #4765: Add missing FieldCell wrapper to customer process ticket…

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerArticle.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerArticle.tt
@@ -15,29 +15,31 @@
 # --
 [% RenderBlockStart("rw:Article") %]
 <div class="Row">
-    <div class="Field">
-        <input type="text" id="Subject[% Data.IDSuffix | html %]" name="Subject" value="[% Data.Subject | html %]" class="W75pc [% Data.ValidateRequired | html %] [% Data.SubjectServerError | html %] Validate_DependingRequiredAND Validate_Depending_RichText Validate_Depending_AttachmentExists Validate_Depending_TimeUnits"/>
-    </div>
-[% RenderBlockStart("rw:Article:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            <input type="text" id="Subject[% Data.IDSuffix | html %]" name="Subject" value="[% Data.Subject | html %]" class="W75pc [% Data.ValidateRequired | html %] [% Data.SubjectServerError | html %] Validate_DependingRequiredAND Validate_Depending_RichText Validate_Depending_AttachmentExists Validate_Depending_TimeUnits"/>
         </div>
-    </div>
+[% RenderBlockStart("rw:Article:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Article:DescriptionLong") %]
-    <label class="[% Data.MandatoryClass | html %]" for="Subject">
+        <label class="[% Data.MandatoryClass | html %]" for="Subject">
 [% RenderBlockStart("LabelSpanSubject") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpanSubject") %]
         [% Data.LabelSubject | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Article:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:Article:DescriptionShort") %]
-    <div id="Subject[% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="Subject[% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="Subject[% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="Subject[% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 
 <div class="RichTextHolder">

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerPriority.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerPriority.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:Priority") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:Priority:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:Priority:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Priority:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Priority:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Data.DescriptionShort | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Data.DescriptionShort | html %]</p>
 [% RenderBlockEnd("rw:Priority:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:Priority") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerQueue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerQueue.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:Queue") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:Queue:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:Queue:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Queue:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Queue:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:Queue:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:Queue") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerSLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerSLA.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:SLA") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:SLA:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:SLA:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:SLA:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:SLA:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Data.DescriptionShort | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Data.DescriptionShort | html %]</p>
 [% RenderBlockEnd("rw:SLA:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:SLA") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerService.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:Service") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:Service:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:Service:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Service:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Service:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:Service:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:Service") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerState.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerState.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:State") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:State:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:State:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:State:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:State:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:State:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:State") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerTitle.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerTitle.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:Title") %]
 <div class="Row">
-    <div class="Field">
-        <input class="W50pc DynamicFieldText [% Data.ValidateRequired | html %] [% Data.ServerError | html %]" type="text" name="[% Data.FieldID | html %]" id="[% Data.FieldID | html %][% Data.IDSuffix | html %]" value="[% Data.Value | html %]"/>
-    </div>
-[% RenderBlockStart("rw:Title:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-           <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            <input class="W50pc DynamicFieldText [% Data.ValidateRequired | html %] [% Data.ServerError | html %]" type="text" name="[% Data.FieldID | html %]" id="[% Data.FieldID | html %][% Data.IDSuffix | html %]" value="[% Data.Value | html %]"/>
         </div>
-    </div>
+[% RenderBlockStart("rw:Title:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+               <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Title:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Title:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:Title:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:Title") %]

--- a/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerType.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProcessManagement/CustomerType.tt
@@ -15,28 +15,30 @@
 # --
 [% RenderBlockStart("rw:Type") %]
 <div class="Row">
-    <div class="Field">
-        [% Data.Content %]
-    </div>
-[% RenderBlockStart("rw:Type:DescriptionLong") %]
-    <div class="Tooltip oooTooltip">
-        <i class="ooofo ooofo-help"></i>
-        <div class="Content">
-            <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+    <div class="FieldCell">
+        <div class="Field">
+            [% Data.Content %]
         </div>
-    </div>
+[% RenderBlockStart("rw:Type:DescriptionLong") %]
+        <div class="Tooltip oooTooltip">
+            <i class="ooofo ooofo-help"></i>
+            <div class="Content">
+                <p>[% Translate(Data.DescriptionLong) | html | html_line_break %]</p>
+            </div>
+        </div>
 [% RenderBlockEnd("rw:Type:DescriptionLong") %]
-    <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
+        <label for="[% Data.FieldID | html %][% Data.IDSuffix | html %]" class="[% Data.MandatoryClass | html %]">
 [% RenderBlockStart("LabelSpan") %]
-        <span class="Marker">*</span>
+            <span class="Marker">*</span>
 [% RenderBlockEnd("LabelSpan") %]
         [% Data.Label | html %]
-    </label>
+        </label>
 [% RenderBlockStart("rw:Type:DescriptionShort") %]
-    <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
+        <p class="FieldExplanation ooo12g">[% Translate(Data.DescriptionShort) | html %]</p>
 [% RenderBlockEnd("rw:Type:DescriptionShort") %]
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
-    <div class="Clear"></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]Error" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div id="[% Data.FieldID | html %][% Data.IDSuffix | html %]ServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
+        <div class="Clear"></div>
+    </div>
 </div>
 [% RenderBlockEnd("rw:Type") %]


### PR DESCRIPTION
###  Fixes #4765 – Missing `FieldCell` wrapper in Customer Portal Process Ticket templates

This PR addresses a UI issue in the **Customer Portal** of OTOBO when using **Process Tickets with active Activity Dialogs**.

### Problem

The input fields for built-in fields (like `Title`, `Queue`, `Service`, etc.) do **not show the floating labels correctly**, because the required `FieldCell` wrapper `<div>` is missing in the templates.

This only affects **Customer Portal process tickets**, not the agent interface.

Dynamic fields are not affected, as their templates already include the correct `FieldCell` container.

###  Solution

The following template files were updated to include the missing wrapper:

- `CustomerArticle.tt`
- `CustomerPriority.tt`
- `CustomerQueue.tt`
- `CustomerService.tt`
- `CustomerSLA.tt`
- `CustomerState.tt`
- `CustomerTitle.tt`
- `CustomerType.tt`

Each input field is now correctly wrapped inside:

```html
<div class="FieldCell">
    <div class="Field">
        <input ... />
    </div>
</div>
