### PR TITLE
Issue #4619: Allow whitespace in extra dump options.

### DIFF
--- a/scripts/backup.pl
+++ b/scripts/backup.pl
@@ -890,7 +890,7 @@ sub HandleExtraDumpOptions {
     my ( $OptName, $OptValue ) = @_;
 
     # be a bit paranoid here
-    if ( $OptValue !~ /^[\-a-zA-Z0-9=]+$/ ) {
+    if ( $OptValue !~ /^[\-a-zA-Z0-9= ]+$/ ) {
         die "The value '$OptValue' is not allowed for $OptName. Please pass valid Extra Dump Options.";
     }
 


### PR DESCRIPTION
Example: --extra-dump-options="-P 3307" for passing the port to mysqldump / mariadbdump.

references #4619