### PR TITLE
Issue #4797: Removed hardcoded skin parameter from call to CSS generation.

### DIFF
--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -761,7 +761,7 @@ sub Login {
     }
 
     # Generate the minified CSS and JavaScript files and the tags referencing them (see LayoutLoader)
-    $Self->LoaderCreateAgentCSSCalls( Skin => 'default' );
+    $Self->LoaderCreateAgentCSSCalls();
     $Self->LoaderCreateAgentJSCalls();
     $Self->LoaderCreateJavaScriptTranslationData();
     $Self->LoaderCreateJavaScriptTemplateData();

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -766,7 +766,7 @@ sub Login {
     $Self->LoaderCreateJavaScriptTranslationData();
     $Self->LoaderCreateJavaScriptTemplateData();
 
-    # we need the baselink for VerfifiedGet() of selenium tests
+    # we need the baselink for VerifiedGet() of selenium tests
     $Self->AddJSData(
         Key   => 'Baselink',
         Value => $Self->{Baselink},
@@ -1510,7 +1510,7 @@ sub Header {
             my $ToolBarItemSeparatorMyTickets = 0;
             my $ToolBarItemSeparatorSearch    = 0;
 
-            # Check which seperator is needed
+            # Check which separator is needed
             SHORTCUTAVAILIBLE:
             for my $Key ( sort keys %Modules ) {
                 next SHORTCUTAVAILIBLE if !%{ $Modules{$Key} };
@@ -4582,14 +4582,14 @@ sub CustomerFooter {
         );
 
         for my $Link ( sort keys %{$FooterLinks} ) {
-            my $SubstitudedLink = $Link;
+            my $SubstitutedLink = $Link;
             for my $Option (qw/HttpType FQDN ScriptAlias/) {
-                $SubstitudedLink =~ s/<OTOBO_CONFIG_$Option>/$URLConfig{ $Option }/g;
+                $SubstitutedLink =~ s/<OTOBO_CONFIG_$Option>/$URLConfig{ $Option }/g;
             }
 
             push @FooterLinks, {
                 Description => $FooterLinks->{$Link},
-                Target      => $SubstitudedLink,
+                Target      => $SubstitutedLink,
             };
         }
 
@@ -6847,7 +6847,7 @@ sub SetCookie {
         # the configured value is the regular case
         $SameSite //= $ConfigObject->Get('SessionSameSite');
 
-        # fallback when neiter configured or passed from command line
+        # fallback when neither configured or passed from command line
         $SameSite //= 'lax';
 
         # lower case
@@ -6873,7 +6873,7 @@ sub SetCookie {
         # the configured value is the regular case
         $Path //= $ConfigObject->Get('ScriptAlias');
 
-        # fallback when neiter configured or passed from command line
+        # fallback when neither configured or passed from command line
         $Path //= '';
 
         # leading slash unless there already is a leading slash


### PR DESCRIPTION
Effectively, passing the Skin parameter subsequently bypasses every
sysconfig mechanism and fixates the Skin on default.

closes #4797