### PR TITLE
Issue #4800: Ensures tables span full width in rich text editor

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -273,6 +273,7 @@ Core.UI.RichTextEditor = (function (TargetNS) {
                 tableProperties: {
                     defaultProperties: {
                         alignment: 'center',
+                        width: '100%'
                     }
                 },
                 contentToolbar: [

--- a/var/httpd/htdocs/skins/Agent/default/css/RichTextArticleContent.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/RichTextArticleContent.css
@@ -28,6 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 .ck-content figure.table {
     margin: 0 0 0 0;
+    width: 100%;
 }
 
 .ck-content p {


### PR DESCRIPTION
Sets default table width to 100% in both editor configuration and article content styling.