### PR TITLE
Removed obsolete TODO comment in BaseText driver.

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -528,7 +528,6 @@ sub EditFieldValueValidate {
         $Value = [$Value];
     }
 
-    # TODO: check whether EditFieldValueGet returns ('first','second','','','fifth','') in case of added but unfilled multivalue fields
     my $ValueItemsPresent = 0;
     for my $ValueItem ( @{$Value} ) {
 


### PR DESCRIPTION
Answer: Yes, it does.

Case: Normal text field, Multivalue. Constellation in AgentTicketPhone:

<img width="506" height="183" alt="grafik" src="https://github.com/user-attachments/assets/a0bdaec3-0a47-4b2f-a88a-cfc7123f8c3e" />

Debug print at point of TODO comment:

```perl
#line 532  /opt/otobo/bin/psgi-bin/../../Kernel/System/DynamicField/Driver/BaseText.pm
$Value = ["", "ab", "", "bc", ""]
```