### PR TITLE
Issue #4852: indicate that chunking is finished per default

### DIFF
--- a/Kernel/System/ImportExport.pm
+++ b/Kernel/System/ImportExport.pm
@@ -2282,7 +2282,7 @@ sub Export {
         Success            => 0,
         Failed             => 0,
         DestinationContent => [],
-        ChunkingFinished   => $ObjectBackend->{ChunkingFinished},    # TODO: this is not nice
+        ChunkingFinished   => $ObjectBackend->{ChunkingFinished},    # TODO: it is not nice to access object attributes directly
     );
 
     EXPORTDATAROW:

--- a/Kernel/System/ImportExport/ObjectBackend/Ticket.pm
+++ b/Kernel/System/ImportExport/ObjectBackend/Ticket.pm
@@ -108,7 +108,8 @@ sub new {
         TicketNumberIDRelation => {},
         AllFoundTicketIDs      => undef,    # will be initialized in first call to ExportDataGet()
         LastHandledIndex       => -1,       # used for chunking
-        ChunkingFinished       =>  0,       # indicate that chunking is finished
+        ChunkingFinished       =>  1,       # indicate that chunking is finished, which is kind of true when no chunking is requested
+
     }, $Type;
 }
 
@@ -889,6 +890,9 @@ sub ExportDataGet {
             UserID     => $Param{UserID},
         );
         if ( ( $Param{ChunkSize} // 0 ) >= 1 ) {
+
+            # chunked mode,
+            $Self->{ChunkingFinished} = 0;
 
             # search only on the first invocation
             $Self->{AllFoundTicketIDs} //= [ $Self->_TicketSearch(%TicketSearchParam) ];

--- a/Kernel/System/ImportExport/ObjectBackend/Translations.pm
+++ b/Kernel/System/ImportExport/ObjectBackend/Translations.pm
@@ -74,7 +74,7 @@ sub new {
     return bless {
         AllRows          => undef,    # will be initialized in first call to ExportDataGet()
         LastHandledIndex => -1,       # used for chunking
-        ChunkingFinished =>  1,       # indicate that chunking is finished
+        ChunkingFinished =>  1,       # indicate that chunking is finished, which is kind of true when no chunking is requested
     }, $Type;
 }
 


### PR DESCRIPTION
An infinite loop was entered when exporting tickets without chunking. This was because the state indicator 'ChunkingFinished' was set incorrectly in that case. This change makes the export of tickets behave the same way as the export of translations.