### PR TITLE
Issue #4858: add the method IsExportComplete()

### DIFF
--- a/Kernel/System/ImportExport.pm
+++ b/Kernel/System/ImportExport.pm
@@ -2278,11 +2278,19 @@ sub Export {
         unshift $ExportData->@*, \@ColumnNames;
     }
 
+    # Backends with support for chunking must provide the method IsExportComplete().
+    # Backends without support for chunking do not have to provide that method. An undefined
+    # value for ChunkingFinished indicates no support for chunking.
+    my $ChunkingFinished;
+    if ( $ObjectBackend->can('IsExportComplete') ) {
+        $ChunkingFinished = $ObjectBackend->IsExportComplete;
+    }
+
     my %Result = (
         Success            => 0,
         Failed             => 0,
         DestinationContent => [],
-        ChunkingFinished   => $ObjectBackend->{ChunkingFinished},    # TODO: it is not nice to access object attributes directly
+        ChunkingFinished   => $ChunkingFinished,
     );
 
     EXPORTDATAROW:

--- a/Kernel/System/ImportExport/ObjectBackend/Ticket.pm
+++ b/Kernel/System/ImportExport/ObjectBackend/Ticket.pm
@@ -1066,6 +1066,21 @@ sub ExportDataGet {
     return \@ExportData;
 }
 
+=head2 IsExportComplete()
+
+Indicate whether the last C<ExportDataGet()> has returned the last chunk of data.
+A true value is also returned when chunking had not been activated.
+
+    my $ChunkingFinished = $ObjectBackend->IsExportComplete;
+
+=cut
+
+sub IsExportComplete {
+    my ($Self) = @_;
+
+    return $Self->{ChunkingFinished};
+}
+
 =head2 ImportDataSave()
 
 imports a single entity of the import data. An entity is either a ticket or an article.

--- a/Kernel/System/ImportExport/ObjectBackend/Translations.pm
+++ b/Kernel/System/ImportExport/ObjectBackend/Translations.pm
@@ -300,6 +300,21 @@ sub ExportDataGet {
     );
 }
 
+=head2 IsExportComplete()
+
+Indicate whether the last C<ExportDataGet()> has returned the last chunk of data.
+A true value is also returned when chunking had not been activated.
+
+    my $ChunkingFinished = $ObjectBackend->IsExportComplete;
+
+=cut
+
+sub IsExportComplete {
+    my ($Self) = @_;
+
+    return $Self->{ChunkingFinished};
+}
+
 =head2 ImportDataSave()
 
 import one row of the import data


### PR DESCRIPTION
as a direct replacement of accessing the hash attribute 'ChunkingFinished'