### PR TITLE
Issue #4909: Allowed empty values in entity-type sysconfigs.

### DIFF
--- a/Kernel/System/SysConfig/ValueType/Entity.pm
+++ b/Kernel/System/SysConfig/ValueType/Entity.pm
@@ -134,6 +134,9 @@ sub SettingEffectiveValueCheck {
         EntitySubType => $EntitySubType,
     );
 
+    # for entities, empty values are valid
+    push @ValidValues, '';
+
     if ( !grep { $_ eq $Param{EffectiveValue} } @ValidValues ) {
         $Result{Error} = "Entity value is invalid($Param{EffectiveValue})!";
         return %Result;


### PR DESCRIPTION
SysConfig values can be of value type Entity, which allows to use e.g. dynamic fields, queues and more as dropdowns in sysconfig settings. However, it was until now not possible to leave the default value empty, hindering usage of entity value types e.g. in packages.

closes #4909