### PR TITLE
Issue #4888: Implemented color variables for warn and error widgets.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
@@ -1134,15 +1134,14 @@ input.FilterBox {
 }
 
 .WidgetSimple .WidgetMessage.Error {
-    background: var(--colTextErr);
-    color: rgba(255, 255, 255, 0.8);
+    background: var(--colNotifyErr);
+    color: var(--colTextDark);
     border: 0px;
 }
 
 .WidgetSimple .WidgetMessage.Warning {
-    background: #F7AE40;
-    border-color: #D18F2B;
-    color: #774a06;
+    background: var(--colNotifyWarn);
+    color: var(--colTextDark);
 }
 
 .WidgetSimple .WidgetMessage.Warning * {


### PR DESCRIPTION
Pictures with changes in place:

<img width="466" height="268" alt="image" src="https://github.com/user-attachments/assets/5571f4a3-f64d-4206-a0a4-5268bce8d988" />

<img width="800" height="256" alt="image" src="https://github.com/user-attachments/assets/6ab368a2-f8da-4079-832b-ee0c653005f9" />

<img width="1491" height="244" alt="Bildschirmfoto_20251210_150826" src="https://github.com/user-attachments/assets/d0a3a62a-f231-45d8-8293-48700bdb81fd" />

closes #4888