### PR TITLE
Issue #4816: Fix styles for richtext headings

### DIFF
--- a/scripts/test/EmailParser/MultipartMixed.t
+++ b/scripts/test/EmailParser/MultipartMixed.t
@@ -248,7 +248,7 @@ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
-*/.ck-content{text-wrap:wrap;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:12px;line-height:1.2}.ck-content *{font-family:inherit;font-size:inherit;line-height:inherit}.ck-content figure.table{margin:0 0 0 0;width:100%}.ck-content p{margin-top:0;margin-bottom:0}.ck-content h1{font-size:2em}.ck-content h2{font-size:1.5em}.ck-content h3{font-size:1.17em}.ck-content h5{font-size:.83em}.ck-content h6{font-size:.67em}.ck-content blockquote{font-style:normal!important;border-left:solid #000099 1.5pt!important;padding:0 0 0 4pt!important;margin:0}.ck-content ul,.ck-content ol{padding:0 50px}.ck-content figure.image:not(.image-style-align-center,.image-style-block-align-right,.image-style-align-left,.image-style-align-right){max-width:calc(100% - var(--ck-image-style-spacing));margin-left:0;margin-right:auto}.ck-content code{font-family:monospace}
+*/.ck-content{text-wrap:wrap;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:12px;line-height:1.2;font-weight:normal;color:#000000;margin-bottom:0}.ck-content *{font-family:inherit;font-size:inherit;line-height:inherit;font-weight:inherit;color:inherit;margin-bottom:inherit}.ck-content figure.table{margin:0 0 0 0;width:100%}.ck-content p{margin-top:0;margin-bottom:0}.ck-content h1{font-size:2em;font-weight:bold;margin-bottom:15px}.ck-content h2{font-size:1.5em;font-weight:bold;margin-bottom:10px}.ck-content h3{font-size:1.17em;font-weight:bold;margin-bottom:5px}.ck-content h4{font-size:1em;font-weight:bold;margin-bottom:5px}.ck-content h5{font-size:.83em;font-weight:bold;margin-bottom:5px}.ck-content h6{font-size:.67em;font-weight:bold}.ck-content blockquote{font-style:normal!important;border-left:solid #000099 1.5pt!important;padding:0 0 0 4pt!important;margin:0}.ck-content ul,.ck-content ol{padding:0 50px}.ck-content figure.image:not(.image-style-align-center,.image-style-block-align-right,.image-style-align-left,.image-style-align-right){max-width:calc(100% - var(--ck-image-style-spacing));margin-left:0;margin-right:auto}.ck-content code{font-family:monospace}
 .ck-content {}</style></head><body class="ck-content">Hello,<br/>
 <br/>
 This is the forwarded message...<br/>
@@ -264,7 +264,7 @@ END_HTML
                 ContentType     => 'text/html; charset=utf-8',
                 Disposition     => 'inline',
                 Filename        => 'file-1.html',
-                Filesize        => 15998,
+                Filesize        => 16326,
                 MimeType        => 'text/html'
             },
         ],

--- a/var/httpd/htdocs/skins/Agent/default/css/RichTextArticleContent.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/RichTextArticleContent.css
@@ -18,12 +18,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 12px;
     line-height: 1.2;
+    font-weight: normal;
+    color: #000000;
+    margin-bottom: 0px;
 }
 
 .ck-content * {
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
+    font-weight: inherit;
+    color: inherit;
+    margin-bottom: inherit;
 }
 
 .ck-content figure.table {
@@ -38,22 +44,37 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 .ck-content h1 {
     font-size: 2em;
+    font-weight: bold;
+    margin-bottom: 15px;
 } 
 
 .ck-content h2 {
     font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 10px;
 }
 
 .ck-content h3 {
     font-size: 1.17em;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.ck-content h4 {
+    font-size: 1em;
+    font-weight: bold;
+    margin-bottom: 5px;
 }
 
 .ck-content h5 {
     font-size: 0.83em;
+    font-weight: bold;
+    margin-bottom: 5px;
 } 
 
 .ck-content h6 {
     font-size: 0.67em;
+    font-weight: bold;
 } 
 
 .ck-content blockquote {

--- a/var/httpd/htdocs/skins/Customer/default/css/RichTextArticleContent.css
+++ b/var/httpd/htdocs/skins/Customer/default/css/RichTextArticleContent.css
@@ -18,14 +18,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 1.3;
+    font-weight: normal;
     color: #00023c;
+    margin-bottom: 0px;
 }
 
 .ck-content * {
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
+    font-weight: inherit;
     color: inherit;
+    margin-bottom: inherit;
 }
 
 .ck-content.CustomerUI {
@@ -38,6 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 .ck-content figure.table {
     margin: 0 0 0 0;
+    width: 100%;
 }
 
 .ck-content p {
@@ -47,23 +52,38 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 .ck-content h1 {
     font-size: 2em;
+    font-weight: bold;
+    margin-bottom: 15px;
 } 
 
 .ck-content h2 {
     font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 10px;
 }
 
 .ck-content h3 {
     font-size: 1.17em;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.ck-content h4 {
+    font-size: 1em;
+    font-weight: bold;
+    margin-bottom: 5px;
 }
 
 .ck-content h5 {
     font-size: 0.83em;
+    font-weight: bold;
+    margin-bottom: 5px;
 } 
 
 .ck-content h6 {
     font-size: 0.67em;
-}  
+    font-weight: bold;
+} 
 
 .ck-content blockquote {
     font-style: normal !important;
@@ -75,7 +95,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 .ck-content ul,
 .ck-content ol  
 {
-     padding: 0 50px;
+    padding: 0 50px;
 }
 
 /* default image style */


### PR DESCRIPTION
Heading styles were not sufficiently defined which resulted in different looks while editing and in the finished article. These styles have now been standardized to be consistent.