### PR TITLE
Issue #4953: fetch CPAN distribution files via HTTPS

### DIFF
--- a/bin/docker/carton
+++ b/bin/docker/carton
@@ -2690,7 +2690,9 @@ $fatpacked{"Carton/Builder.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'
   
       my @mirrors = ($self->mirror);
       push @mirrors, Carton::Mirror->default if $self->custom_mirror;
-      push @mirrors, Carton::Mirror->new('http://backpan.perl.org/');
+      # Hotpatch by the OTOBO Team 2025-12-15.
+      # Do not fall back to installing from the BackPan.
+      #push @mirrors, Carton::Mirror->new('http://backpan.perl.org/');
   
       @mirrors;
   }
@@ -3567,7 +3569,10 @@ $fatpacked{"Carton/Mirror.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'C
   use strict;
   use Class::Tiny qw( url );
   
-  our $DefaultMirror = 'http://cpan.metacpan.org/';
+  # Hotpatch by the OTOBO Team 2025-12-15.
+  # Fetch the distributions via HTTPS
+  #our $DefaultMirror = 'http://cpan.metacpan.org/';
+  our $DefaultMirror = 'https://cpan.metacpan.org/';
   
   sub BUILDARGS {
       my($class, $url) = @_;

--- a/otobo.web.dockerfile
+++ b/otobo.web.dockerfile
@@ -91,6 +91,7 @@ ENV LANG=C.UTF-8
 # On the Docker host the fatpacked /opt/otobo_install/vendor/bin/carton can be copied to bin/docker/carton
 # in the Git sandbox.
 #   docker cp otoelfeins-web-1:/opt/otobo/vendor/bin/carton bin/docker/carton
+# Look for 'Hotpatch by the OTOBO Team' in the git diff and apply the hot patches to the new version.
 #   git add bin/docker/carton
 #
 # Note that the variable $DOCKER_TAG is already substituted by Docker.


### PR DESCRIPTION
never fall back to the BackPan