### PR TITLE
Issue #4988: Use undef for empty dynamic field values.

### DIFF
--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2019 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -490,7 +490,7 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, $ValueItem;
+                push @TmpValues, ( $ValueItem || undef );
 
                 next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
 

--- a/Kernel/System/DynamicField/Driver/BaseDatabase.pm
+++ b/Kernel/System/DynamicField/Driver/BaseDatabase.pm
@@ -490,11 +490,15 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, ( $ValueItem || undef );
 
-                next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
+                if ( !defined $ValueItem || $ValueItem eq '' ) {
+                    push @TmpValues, undef;
 
-                push @Data, @TmpValues;
+                    next VALUEITEM;
+                }
+
+                push @TmpValues, $ValueItem;
+                push @Data,      @TmpValues;
                 @TmpValues = ();
             }
 

--- a/Kernel/System/DynamicField/Driver/BaseEntity.pm
+++ b/Kernel/System/DynamicField/Driver/BaseEntity.pm
@@ -1,7 +1,7 @@
 # --
 # OTOBO is a web-based ticketing system for service organisations.
 # --
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -491,7 +491,7 @@ sub EditFieldValueGet {
         my @Data;
         VALUEITEM:
         for my $ValueItem (@DataAll) {
-            push @TmpValues, $ValueItem;
+            push @TmpValues, ( $ValueItem || undef );
 
             next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
 

--- a/Kernel/System/DynamicField/Driver/BaseEntity.pm
+++ b/Kernel/System/DynamicField/Driver/BaseEntity.pm
@@ -491,11 +491,15 @@ sub EditFieldValueGet {
         my @Data;
         VALUEITEM:
         for my $ValueItem (@DataAll) {
-            push @TmpValues, ( $ValueItem || undef );
 
-            next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
+            if ( !defined $ValueItem || $ValueItem eq '' ) {
+                push @TmpValues, undef;
 
-            push @Data, @TmpValues;
+                next VALUEITEM;
+            }
+
+            push @TmpValues, $ValueItem;
+            push @Data,      @TmpValues;
             @TmpValues = ();
         }
 

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -467,7 +467,7 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, $ValueItem;
+                push @TmpValues, ( $ValueItem || undef );
 
                 next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
 

--- a/Kernel/System/DynamicField/Driver/BaseSelect.pm
+++ b/Kernel/System/DynamicField/Driver/BaseSelect.pm
@@ -467,11 +467,15 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, ( $ValueItem || undef );
 
-                next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
+                if ( !defined $ValueItem || $ValueItem eq '' ) {
+                    push @TmpValues, undef;
 
-                push @Data, @TmpValues;
+                    next VALUEITEM;
+                }
+
+                push @TmpValues, $ValueItem;
+                push @Data,      @TmpValues;
                 @TmpValues = ();
             }
 

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -491,11 +491,15 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, ( $ValueItem || undef );
 
-                next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
+                if ( !defined $ValueItem || $ValueItem eq '' ) {
+                    push @TmpValues, undef;
 
-                push @Data, @TmpValues;
+                    next VALUEITEM;
+                }
+
+                push @TmpValues, $ValueItem;
+                push @Data,      @TmpValues;
                 @TmpValues = ();
             }
 

--- a/Kernel/System/DynamicField/Driver/BaseText.pm
+++ b/Kernel/System/DynamicField/Driver/BaseText.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -491,7 +491,7 @@ sub EditFieldValueGet {
             my @Data;
             VALUEITEM:
             for my $ValueItem (@DataAll) {
-                push @TmpValues, $ValueItem;
+                push @TmpValues, ( $ValueItem || undef );
 
                 next VALUEITEM if ( !defined $ValueItem || $ValueItem eq '' );
 


### PR DESCRIPTION
In MultiValue case, sub EditFieldValueGet needs to put undef to prevent ValueIsDifferent from false positives (when a value stays the same but is reported as changed).

closes #4988