### PR TITLE
Issue #4994: rename parameter TestScriptPathes to TestScriptPaths

### DIFF
--- a/Kernel/System/Console/Command/Dev/UnitTest/Run.pm
+++ b/Kernel/System/Console/Command/Dev/UnitTest/Run.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -98,9 +98,11 @@ sub Configure {
         ValueRegex  => qr/.*/smx,
         Multiple    => 1
     );
+
+    # none, one or multiple directories or scripts can be passed
     $Self->AddArgument(
         Name        => 'test-script-path',
-        Description => "Pathes to directories with test scripts or to single test scripts. All other test selection options will be ignored.",
+        Description => "Paths to directories with test scripts or to single test scripts. All other test selection options will be ignored.",
         Required    => 0,
         ValueRegex  => qr/.*/smx,
         Slurpy      => 1,
@@ -125,15 +127,15 @@ sub Run {
     );
 
     my $FunctionResult = $Kernel::OM->Get('Kernel::System::UnitTest')->Run(
-        Tests            => $Self->GetOption('test'),
-        TestScriptPathes => $Self->GetArgument('test-script-path'),
-        Directory        => $Self->GetOption('directory'),
-        SOPMFiles        => $Self->GetOption('sopm'),
-        Packages         => $Self->GetOption('package'),
-        Verbose          => $Self->GetOption('verbose'),
-        Merge            => $Self->GetOption('merge'),
-        Shuffle          => $Self->GetOption('shuffle'),
-        PostTestScripts  => $Self->GetOption('post-test-script'),
+        Tests           => $Self->GetOption('test'),
+        TestScriptPaths => $Self->GetArgument('test-script-path'),
+        Directory       => $Self->GetOption('directory'),
+        SOPMFiles       => $Self->GetOption('sopm'),
+        Packages        => $Self->GetOption('package'),
+        Verbose         => $Self->GetOption('verbose'),
+        Merge           => $Self->GetOption('merge'),
+        Shuffle         => $Self->GetOption('shuffle'),
+        PostTestScripts => $Self->GetOption('post-test-script'),
     );
 
     return $Self->ExitCodeOk if $FunctionResult;

--- a/Kernel/System/UnitTest.pm
+++ b/Kernel/System/UnitTest.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -92,7 +92,7 @@ run all or some tests located in C<scripts/test/**/*.t> and print the result.
             'JSON',
             'User'
         ],
-        TestScriptPathes => [                   # optional, execute specific test scripts or scripts in dir
+        TestScriptPaths => [                    # optional, execute specific test scripts or scripts in directory
             'scripts/test/DB',
             'scripts/test/NutsAndBolts.t'
         ],
@@ -138,13 +138,13 @@ sub Run {
     my ( $Self, %Param ) = @_;
 
     # handle parameters
-    my $Verbosity        = $Param{Verbose} // 0;    # print test results when set to 1
-    my $Merge            = $Param{Merge}   // 0;
-    my $DoShuffle        = $Param{Shuffle} // 0;
-    my $DirectoryParam   = $Param{Directory};       # either a scalar or an array ref
-    my @SOPMFiles        = ( $Param{SOPMFiles}        // [] )->@*;
-    my @Packages         = ( $Param{Packages}         // [] )->@*;
-    my @TestScriptPathes = ( $Param{TestScriptPathes} // [] )->@*;
+    my $Verbosity       = $Param{Verbose} // 0;    # print test results when set to 1
+    my $Merge           = $Param{Merge}   // 0;
+    my $DoShuffle       = $Param{Shuffle} // 0;
+    my $DirectoryParam  = $Param{Directory};       # either a scalar or an array ref
+    my @SOPMFiles       = ( $Param{SOPMFiles}       // [] )->@*;
+    my @Packages        = ( $Param{Packages}        // [] )->@*;
+    my @TestScriptPaths = ( $Param{TestScriptPaths} // [] )->@*;
 
     # The tests specified with the option --test indicate the file name
     # or optionally one or more parent directories.
@@ -161,10 +161,10 @@ sub Run {
     my $Host         = hostname();
 
     my @ActualTestScripts;
-    if (@TestScriptPathes) {
+    if (@TestScriptPaths) {
 
         # only the explicit list counts, all other options are ignored
-        for my $TestScriptPath (@TestScriptPathes) {
+        for my $TestScriptPath (@TestScriptPaths) {
             if ( -f $TestScriptPath ) {
                 push @ActualTestScripts, $TestScriptPath;
             }


### PR DESCRIPTION
"Pathes" is a misspelling even in computer science context, see https://en.wikipedia.org/wiki/Path_(computing)