### PR TITLE
Fixed typos in code comments.

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -2435,7 +2435,7 @@ sub SyncWithS3 {
     while (1) {
 
         # run a blocking GET request to S3, getting all keys below the prefix
-        # The keys are the pathes of files relative to Kernel/Config/Files
+        # The keys are the paths of files relative to Kernel/Config/Files
         my %SubPath2Properties = $StorageS3Object->ListObjects(
             Prefix    => "$FilesPrefix/",
             Delimiter => '',

--- a/Kernel/Modules/AdminDynamicFieldDateTime.pm
+++ b/Kernel/Modules/AdminDynamicFieldDateTime.pm
@@ -467,7 +467,7 @@ sub _ChangeAction {
         }
     }
 
-    # return to change screen if errors occured
+    # return to change screen if errors occurred
     if (%Errors) {
         return $Self->_ShowScreen(
             %Param,

--- a/Kernel/Output/HTML/ArticleCheck/SMIME.pm
+++ b/Kernel/Output/HTML/ArticleCheck/SMIME.pm
@@ -592,7 +592,7 @@ sub Check {
             );
         }
 
-        # some errors occured
+        # some errors occurred
         else {
 
             $ArticleObject->ArticleFlagSet(

--- a/Kernel/System/Cache/FileStorable.pm
+++ b/Kernel/System/Cache/FileStorable.pm
@@ -196,7 +196,7 @@ sub CleanUp {
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    # Returns absolute pathes without trailing '/' for directories
+    # Returns absolute paths without trailing '/' for directories
     my @ToBeDeletedTypes = $MainObject->DirectoryRead(
         Directory => $Self->{CacheDirectory},
         Filter    => $Param{Type} || '*',
@@ -207,7 +207,7 @@ sub CleanUp {
     if ( $Param{KeepTypes} && ref $Param{KeepTypes} eq 'ARRAY' && $Param{KeepTypes}->@* ) {
         my $KeepTypesRegex = join( '|', map {"\Q$_\E"} @{ $Param{KeepTypes} } );
 
-        # first '/' needed because the members of @ToBeDeletedTypes contains absolute pathes.
+        # first '/' needed because the members of @ToBeDeletedTypes contains absolute paths.
         # second optional '/' is to be on the safe side
         @ToBeDeletedTypes = grep { $_ !~ m{/$KeepTypesRegex/?$}smx } @ToBeDeletedTypes;
     }

--- a/Kernel/System/Console/Command/Dev/Tools/CacheBenchmark.pm
+++ b/Kernel/System/Console/Command/Dev/Tools/CacheBenchmark.pm
@@ -43,7 +43,7 @@ sub Run {
     # get home directory
     my $HomeDir = $Kernel::OM->Get('Kernel::Config')->Get('Home');
 
-    # get all avaliable backend modules
+    # get all available backend modules
     my @BackendModuleFiles = $Kernel::OM->Get('Kernel::System::Main')->DirectoryRead(
         Directory => $HomeDir . '/Kernel/System/Cache/',
         Filter    => '*.pm',

--- a/Kernel/System/PostMaster/DestQueue.pm
+++ b/Kernel/System/PostMaster/DestQueue.pm
@@ -95,7 +95,7 @@ sub GetQueueID {
         }
 
         # Address/Email not matched with any that is configured in the system
-        #   or any error occured while checking it.
+        #   or any error occurred while checking it.
 
         $Self->{CommunicationLogObject}->ObjectLog(
             ObjectLogType => 'Message',
@@ -106,7 +106,7 @@ sub GetQueueID {
     }
 
     # If we get here means that none of the addresses in the message is defined as a system address
-    #   or an error occured while checking it.
+    #   or an error occurred while checking it.
 
     my $Queue   = $Kernel::OM->Get('Kernel::Config')->Get('PostmasterDefaultQueue');
     my $QueueID = $Kernel::OM->Get('Kernel::System::Queue')->QueueLookup(

--- a/Kernel/System/PostMaster/Filter/Decrypt.pm
+++ b/Kernel/System/PostMaster/Filter/Decrypt.pm
@@ -453,7 +453,7 @@ sub _DecryptSMIME {
             }
         }
 
-        # some errors occured
+        # some errors occurred
         else {
             $Param{GetParam}{Signed} = 'Signed message, but unable to verify!';
             return;

--- a/scripts/test/Cache.t
+++ b/scripts/test/Cache.t
@@ -562,7 +562,7 @@ for my $ModuleFile (@BackendModuleFiles) {
             }
         }
 
-        # get all avaliable test files
+        # get all available test files
         my @TestFiles = $MainObject->DirectoryRead(
             Directory => $HomeDir . '/scripts/test/sample/Cache/',
             Filter    => '*',

--- a/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleArray.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminSystemConfigurationExampleArray.t
@@ -680,7 +680,7 @@ my @Tests = (
                 JqueryClick => '.Cancel',
             },
         ],
-        ExpectedResult => [    # Error occured, nothing was changed
+        ExpectedResult => [    # Error occurred, nothing was changed
             '/etc/hosts',
             '/etc/localtime',
         ],


### PR DESCRIPTION
Fixed typos in code comments as requested in #4993

Some of the typos like duplicated `the the` is not part of this branch, it was introduced in `rel-11_0`.