### PR TITLE
Fixed layout in agent personal preferences, standardized wording.

### DIFF
--- a/Kernel/Config/Files/XML/DynamicFields.xml
+++ b/Kernel/Config/Files/XML/DynamicFields.xml
@@ -1350,8 +1350,8 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">Dynamic Fields Overview Limit</Item>
-                <Item Key="Desc" Translatable="1">Dynamic fields limit per page for Dynamic Fields Overview.</Item>
+                <Item Key="Label" Translatable="1">Dynamic field overview limit</Item>
+                <Item Key="Desc" Translatable="1">Dynamic field limit per page for dynamic field overviews.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -3411,9 +3411,9 @@ You can log in via the following URL:
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">UserProfile</Item>
-                <Item Key="Label" Translatable="1">Google Authenticator</Item>
-                <Item Key="Desc" Translatable="1">Enter your shared secret to enable two factor authentication. WARNING: Make sure that you add the shared secret to your generator application and the application works well. Otherwise you will be not able to login anymore without the two factor token.</Item>
-                <Item Key="Key" Translatable="1">Shared Secret</Item>
+                <Item Key="Label" Translatable="1">Two-factor authentication shared secret</Item>
+                <Item Key="Desc" Translatable="1">Enter your shared secret to enable two-factor authentication. WARNING: Make sure that you add the shared secret to your generator application and the application works well. Otherwise you will be not able to login anymore without the two-factor token.</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Block">Input</Item>
                 <Item Key="PrefKey">UserGoogleAuthenticatorSecretKey</Item>
                 <Item Key="ValidateRegex">^([A-Z2-7]{16}|)$</Item>
@@ -3431,8 +3431,8 @@ You can log in via the following URL:
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
                 <Item Key="Label" Translatable="1">Comment</Item>
-                <Item Key="Desc" Translatable="1">This is a Description for Comment on Framework.</Item>
-                <Item Key="Key" Translatable="1">Comment</Item>
+                <Item Key="Desc" Translatable="1">This is a description for comment on framework.</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Block">Input</Item>
                 <Item Key="Data">[% Env("UserComment") %]</Item>
                 <Item Key="PrefKey">UserComment</Item>
@@ -3448,9 +3448,9 @@ You can log in via the following URL:
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">NameX</Item>
-                <Item Key="Desc" Translatable="1">This is a Description for DynamicField on Framework.</Item>
-                <Item Key="Key" Translatable="1">Default value for NameX</Item>
+                <Item Key="Label" Translatable="1">Default value for NameX</Item>
+                <Item Key="Desc" Translatable="1">This is a description for dynamic field on framework.</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Block">Input</Item>
                 <Item Key="Data">[% Env("UserDynamicField_NameX") %]</Item>
                 <Item Key="PrefKey">UserDynamicField_NameX</Item>
@@ -3550,9 +3550,9 @@ You can log in via the following URL:
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">CSV Separator</Item>
+                <Item Key="Label" Translatable="1">CSV separator</Item>
                 <Item Key="Desc" Translatable="1">Select the separator character used in CSV files (stats and searches). If you don't select a separator here, the default separator for your language will be used.</Item>
-                <Item Key="Key" Translatable="1">CSV Separator</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
                         <Item Key=""></Item>
@@ -4264,8 +4264,8 @@ via the Preferences button after logging in.
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">CommunicationLog Overview Limit</Item>
-                <Item Key="Desc" Translatable="1">Communication log limit per page for Communication Log Overview.</Item>
+                <Item Key="Label" Translatable="1">Communication log overview limit</Item>
+                <Item Key="Desc" Translatable="1">Communication log limit per page for communication log overview.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -7649,8 +7649,8 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">Overview Refresh Time</Item>
-                <Item Key="Desc" Translatable="1">If enabled, the different overviews (Dashboard, LockedView, QueueView) will automatically refresh after the specified time.</Item>
+                <Item Key="Label" Translatable="1">Overview refresh time</Item>
+                <Item Key="Desc" Translatable="1">If enabled, the different overviews (Dashboard, Locked View, Queue View) will automatically refresh after the specified time.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
@@ -7676,8 +7676,8 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">Ticket Overview "Small" Limit</Item>
-                <Item Key="Desc" Translatable="1">Ticket limit per page for Ticket Overview "Small".</Item>
+                <Item Key="Label" Translatable="1">Ticket overview “Small” limit</Item>
+                <Item Key="Desc" Translatable="1">Ticket limit per page for ticket overview “Small”.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
@@ -7719,8 +7719,8 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">Ticket Overview "Medium" Limit</Item>
-                <Item Key="Desc" Translatable="1">Ticket limit per page for Ticket Overview "Medium".</Item>
+                <Item Key="Label" Translatable="1">Ticket overview “Medium” limit</Item>
+                <Item Key="Desc" Translatable="1">Ticket limit per page for ticket overview “Medium”.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
@@ -7746,8 +7746,8 @@
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Preferences::Generic</Item>
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
-                <Item Key="Label" Translatable="1">Ticket Overview "Preview" Limit</Item>
-                <Item Key="Desc" Translatable="1">Ticket limit per page for Ticket Overview "Preview".</Item>
+                <Item Key="Label" Translatable="1">Ticket overview “Preview” limit</Item>
+                <Item Key="Desc" Translatable="1">Ticket limit per page for ticket overview “Preview”.</Item>
                 <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
@@ -14753,7 +14753,7 @@ Thanks for your help!
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
                 <Item Key="Label" Translatable="1">Dialog to show after marking a ticket as unseen</Item>
                 <Item Key="Desc" Translatable="1">Configure which screen should be shown after a ticket has been marked as unseen.</Item>
-                <Item Key="Key" Translatable="1">Dialog to show after marking a ticket as unseen</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
                         <Item Key="">-</Item>
@@ -14797,7 +14797,7 @@ Thanks for your help!
                 <Item Key="PreferenceGroup">Miscellaneous</Item>
                 <Item Key="Label" Translatable="1">Dialog to show after marking a ticket as seen</Item>
                 <Item Key="Desc" Translatable="1">Configure which screen should be shown after a ticket has been marked as seen.</Item>
-                <Item Key="Key" Translatable="1">Dialog to show after marking a ticket as seen</Item>
+                <Item Key="Key" Translatable="1"></Item>
                 <Item Key="Data">
                     <Hash>
                         <Item Key="">-</Item>

--- a/scripts/test/Selenium/Output/Preferences/Agent/Generic.t
+++ b/scripts/test/Selenium/Output/Preferences/Agent/Generic.t
@@ -39,8 +39,8 @@ $Selenium->RunTest(
                 Active          => "1",
                 PreferenceGroup => "Miscellaneous",
                 DataSelected    => "25",
-                Key             => "Ticket limit per page for Ticket Overview \"$View\"",
-                Label           => "Ticket Overview \"$View\" Limit",
+                Key             => "Ticket limit per page for ticket overview “$View”.",
+                Label           => "Ticket overview “$View” limit",
                 Module          => "Kernel::Output::HTML::Preferences::Generic",
                 PrefKey         => "UserTicketOverview" . $View . "PageShown",
                 Prio            => "8000",
@@ -85,22 +85,22 @@ $Selenium->RunTest(
         # Create test params.
         my @Tests = (
             {
-                Name  => 'Overview Refresh Time',
+                Name  => 'Overview refresh time',
                 ID    => 'UserRefreshTime',
                 Value => '5',
             },
             {
-                Name  => 'Ticket Overview "Small" Limit',
+                Name  => 'Ticket overview “Small” limit',
                 ID    => 'UserTicketOverviewSmallPageShown',
                 Value => '10',
             },
             {
-                Name  => 'Ticket Overview "Medium" Limit',
+                Name  => 'Ticket overview “Medium” limit',
                 ID    => 'UserTicketOverviewMediumPageShown',
                 Value => '10',
             },
             {
-                Name  => 'Ticket Overview "Preview" Limit',
+                Name  => 'Ticket overview “Preview” limit',
                 ID    => 'UserTicketOverviewPreviewPageShown',
                 Value => '10',
             },


### PR DESCRIPTION
This PR standardizes wording by using sentence case in agent personal preferences.

The `Key` is removed for each setting to have the same look and feel. Here is a before-after screenshot:

![agent-personal-preferences-before-after](https://github.com/user-attachments/assets/7d9239bd-8a92-431e-9b11-c62cf7c536ab)
