### PR TITLE
Issue #2152: Changed behavior of AgentCreateBy notification recipient.

### DIFF
--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -958,7 +958,7 @@ sub _Edit {
     $Param{RecipientsStrg} = $LayoutObject->BuildSelection(
         Data => {
             AgentCreateBy             => Translatable('Agent who created the ticket'),
-            FirstAgentArticleAuthor   => Translatable('Agent who created the first agent article in the ticket'),
+            AgentFirstArticleAuthor   => Translatable('Agent who created the first agent article in the ticket'),
             AgentOwner                => Translatable('Agent who owns the ticket'),
             AgentResponsible          => Translatable('Agent who is responsible for the ticket'),
             AgentWatcher              => Translatable('All agents watching the ticket'),

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -957,8 +957,8 @@ sub _Edit {
 
     $Param{RecipientsStrg} = $LayoutObject->BuildSelection(
         Data => {
-            AgentCreateBy             => Translatable('Agent who created the ticket'),
-            AgentFirstArticleAuthor   => Translatable('Agent who created the first agent article in the ticket'),
+            AgentCreateBy             => Translatable('Agent who created the first article'),
+            AgentCreateByTicket       => Translatable('Agent who created the ticket'),
             AgentOwner                => Translatable('Agent who owns the ticket'),
             AgentResponsible          => Translatable('Agent who is responsible for the ticket'),
             AgentWatcher              => Translatable('All agents watching the ticket'),

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -817,7 +817,6 @@ sub Run {
         # challenge token check for write action
         $LayoutObject->ChallengeTokenCheck();
 
-        my $FormID      = $ParamObject->GetParam( Param => 'FormID' ) || '';
         my %UploadStuff = $ParamObject->GetUploadAll(
             Param  => 'FileUpload',
             Source => 'string',

--- a/Kernel/Modules/AdminNotificationEvent.pm
+++ b/Kernel/Modules/AdminNotificationEvent.pm
@@ -959,6 +959,7 @@ sub _Edit {
     $Param{RecipientsStrg} = $LayoutObject->BuildSelection(
         Data => {
             AgentCreateBy             => Translatable('Agent who created the ticket'),
+            FirstAgentArticleAuthor   => Translatable('Agent who created the first agent article in the ticket'),
             AgentOwner                => Translatable('Agent who owns the ticket'),
             AgentResponsible          => Translatable('Agent who is responsible for the ticket'),
             AgentWatcher              => Translatable('All agents watching the ticket'),

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -643,7 +643,7 @@ sub _RecipientsGet {
 
             if (
                 $Recipient
-                =~ /^Agent(Owner|Responsible|Watcher|WritePermissions|MyQueues|MyServices|MyQueuesMyServices|CreateBy)$/
+                =~ /^Agent(Owner|Responsible|Watcher|WritePermissions|MyQueues|MyServices|MyQueuesMyServices|CreateBy|FirstArticleAuthor)$/
                 )
             {
                 if ( $Recipient eq 'AgentOwner' ) {
@@ -747,7 +747,7 @@ sub _RecipientsGet {
 
                     push @{ $Notification{Data}->{RecipientAgents} }, @UserIDs;
                 }
-                elsif ( $Recipient eq 'FirstAgentArticleAuthor' ) {
+                elsif ( $Recipient eq 'AgentFirstArticleAuthor' ) {
 
                     # Check if the first article was created by an agent.
                     my @Articles = $ArticleObject->ArticleList(
@@ -762,11 +762,7 @@ sub _RecipientsGet {
                 }
                 elsif ( $Recipient eq 'AgentCreateBy' ) {
 
-                    # no notifications should be sent to the admin user
-                    #   this also includes customer-created tickets, which use the admin user as create agent
-                    if ( $Ticket{CreateBy} != 1 ) {
-                        push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
-                    }
+                    push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
                 }
             }
 

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2025 Rother OSS GmbH, https://otobo.io/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -749,17 +749,11 @@ sub _RecipientsGet {
                 }
                 elsif ( $Recipient eq 'AgentCreateBy' ) {
 
-                    # Check if the first article was created by an agent.
-                    my @Articles = $ArticleObject->ArticleList(
-                        TicketID   => $Param{Data}->{TicketID},
-                        SenderType => 'agent',
-                        OnlyFirst  => 1,
-                    );
-
-                    if ( $Articles[0] && $Articles[0]->{ArticleNumber} == 1 ) {
+                    # no notifications should be sent to the admin user
+                    #   this also includes customer-created tickets, which use the admin user as create agent
+                    if ( $Ticket{CreateBy} != 1 ) {
                         push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
                     }
-
                 }
             }
 

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -643,7 +643,7 @@ sub _RecipientsGet {
 
             if (
                 $Recipient
-                =~ /^Agent(Owner|Responsible|Watcher|WritePermissions|MyQueues|MyServices|MyQueuesMyServices|CreateBy|FirstArticleAuthor)$/
+                =~ /^Agent(Owner|Responsible|Watcher|WritePermissions|MyQueues|MyServices|MyQueuesMyServices|CreateBy|CreateByTicket)$/
                 )
             {
                 if ( $Recipient eq 'AgentOwner' ) {
@@ -747,7 +747,7 @@ sub _RecipientsGet {
 
                     push @{ $Notification{Data}->{RecipientAgents} }, @UserIDs;
                 }
-                elsif ( $Recipient eq 'AgentFirstArticleAuthor' ) {
+                elsif ( $Recipient eq 'AgentCreateBy' ) {
 
                     # Check if the first article was created by an agent.
                     my @Articles = $ArticleObject->ArticleList(
@@ -760,7 +760,7 @@ sub _RecipientsGet {
                         push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
                     }
                 }
-                elsif ( $Recipient eq 'AgentCreateBy' ) {
+                elsif ( $Recipient eq 'AgentCreateByTicket' ) {
 
                     push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
                 }

--- a/Kernel/System/Ticket/Event/NotificationEvent.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent.pm
@@ -747,6 +747,19 @@ sub _RecipientsGet {
 
                     push @{ $Notification{Data}->{RecipientAgents} }, @UserIDs;
                 }
+                elsif ( $Recipient eq 'FirstAgentArticleAuthor' ) {
+
+                    # Check if the first article was created by an agent.
+                    my @Articles = $ArticleObject->ArticleList(
+                        TicketID   => $Param{Data}->{TicketID},
+                        SenderType => 'agent',
+                        OnlyFirst  => 1,
+                    );
+
+                    if ( $Articles[0] && $Articles[0]->{ArticleNumber} == 1 ) {
+                        push @{ $Notification{Data}->{RecipientAgents} }, $Ticket{CreateBy};
+                    }
+                }
                 elsif ( $Recipient eq 'AgentCreateBy' ) {
 
                     # no notifications should be sent to the admin user


### PR DESCRIPTION
Do not look for the first agent-created article. Instead, use the agent who created the ticket, as long as it is not the root user.

closes #2152