### PR TITLE
Issue #5026: store the plain message as UTF-8 encoded string

### DIFF
--- a/scripts/test/Selenium/Agent/AgentTicketPlain.t
+++ b/scripts/test/Selenium/Agent/AgentTicketPlain.t
@@ -90,7 +90,7 @@ $Selenium->RunTest(
         my $Location   = $ConfigObject->Get('Home') . '/scripts/test/sample/EmailParser/UTF-8.box';
         my $ContentRef = $Kernel::OM->Get('Kernel::System::Main')->FileRead(
             Location => $Location,
-            Mode     => 'utf8',
+            Mode     => 'binmode',
             Result   => 'SCALAR',
         );
 


### PR DESCRIPTION
that is as a string that has the UTF-8 flag off and contains UTF-8 encoded text. This is thought to be the use case that is relevant in the PostMaster. DBD::mysql makes no difference whether the UTF-8 flag is on of off.