### PR TITLE
Implement native support for RHEL 9.7

### DIFF
--- a/scripts/build-rhel-modules.sh
+++ b/scripts/build-rhel-modules.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+set -Euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+PROJECT_ROOT="$SCRIPT_DIR/.."
+TARGET_LIB="$PROJECT_ROOT/install/local"
+ARCHIVE_NAME="otobo-deps-11.0-rhel-9.7.tar.gz"
+# Directory at /opt/otobo to compress to tar.gz
+ARCHIVE_DIR="install"
+
+if ! command -v cpanm &> /dev/null; then
+    echo "cpanm not found. Installing using dnf..."
+    
+    if [ "$EUID" -ne 0 ]; then
+        echo "Installatin failed. Please provide sudo credentials."
+        sudo dnf install -y perl-App-cpanminus
+    else
+        dnf install -y perl-App-cpanminus
+    fi
+else
+    echo "cpanm is already present. Skipping Installation."
+fi
+
+cd "$PROJECT_ROOT"
+
+if [ -d "$TARGET_LIB" ]; then
+   echo "$TARGET_LIB already exists. Skipping."
+else
+   echo "Creating $TARGET_LIB ..."
+   mkdir -p "$TARGET_LIB/lib/perl5"
+fi
+
+PERL5LIB="$PROJECT_ROOT/install/local/lib/perl5"
+
+# Overwritte default cpanfile for cpanm build
+cp cpanfile.plackup cpanfile -f
+
+if [ -f "cpanfile" ]; then
+    echo "Installing dependencies to $TARGET_LIB..."
+    cpanm --local-lib "$TARGET_LIB" --self-contained --notest --installdeps .
+else
+    echo "Error: Couldn't find cpanfile in $PROJECT_ROOT!"
+    exit 1
+fi
+
+# Make binaries executable
+chmod +x ${TARGET_LIB}/bin/*
+
+tar -zcf ${ARCHIVE_NAME} -C . ${ARCHIVE_DIR}
+echo "Saved modules directory under ${PROJECT_ROOT}/${ARCHIVE_NAME}"

--- a/var/nginx/nginx-ssl.conf
+++ b/var/nginx/nginx-ssl.conf
@@ -1,0 +1,56 @@
+# Config for nginx serving as a reverse proxy for the OTOBO web application.
+
+# This config is based on default.conf in the nginx installation
+
+# The master process runs as root.
+# When no user is configured then the workers will run as nobody.
+#user
+
+proxy_send_timeout 120;
+proxy_read_timeout 99999;
+proxy_buffering    off;
+#tcp_nodelay        on; Already configured in /etc/nginx/nginx.conf
+
+# Do not serve HTTP, but redirect to HTTPS instead.
+# See https://linuxize.com/post/redirect-http-to-https-in-nginx/.
+server {
+    listen 80;
+    listen [::]:80;
+
+    # catch all domains
+    server_name _;
+
+    # 301 Moved Permanently, (in 'SEO-speak', it is said that the 'link-juice' is sent to the new URL).
+    return 301 https://$host:443$request_uri;
+}
+
+# serve HTTPS
+server {
+    listen 443 ssl http2;                # falls back to regular HTTPS over HTTP/1.1 when the browser does not support HTTP/2
+    listen [::]:443 ssl http2;
+
+    # See https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-18-04
+    # See https://ssl-config.mozilla.org/
+    include snippets/ssl-params.conf;
+    # Please add the path to the ssl cert
+    ssl_certificate     /etc/ssl/certs/otobo.de.cert;
+    # Please add the path to the ssl key
+    ssl_certificate_key /etc/ssl/private/otobo.de.nopass.key;
+
+    server_name  localhost;
+
+    # allow large uploads of files
+    client_max_body_size 1G;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    # proxy to the otobo webapp accessible from the host
+    # pass on information about the client
+    location / {
+        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass       http://localhost:5000/;
+    }
+}

--- a/var/nginx/nginx.conf
+++ b/var/nginx/nginx.conf
@@ -1,0 +1,36 @@
+# Config for nginx serving as a reverse proxy for the OTOBO web application.
+
+# This config is based on default.conf in the nginx installation
+
+# The master process runs as root.
+# When no user is configured then the workers will run as nobody.
+#user
+
+proxy_send_timeout 120;
+proxy_read_timeout 99999;
+proxy_buffering    off;
+#tcp_nodelay        on; Already configured in /etc/nginx/nginx.conf
+
+# Do not serve HTTP, but redirect to HTTPS instead.
+# See https://linuxize.com/post/redirect-http-to-https-in-nginx/.
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name  localhost;
+
+    # allow large uploads of files
+    client_max_body_size 1G;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    # proxy to the otobo webapp accessible from the host
+    # pass on information about the client
+    location / {
+        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass       http://localhost:5000/;
+    }
+}

--- a/var/systemd/otobo-daemon.service
+++ b/var/systemd/otobo-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description = Otobo Daemon Service
+Documentation = https://doc.otobo.org
+
+[Service]
+Type = forking
+User = otobo
+Group = otobo
+WorkingDirectory = /opt/otobo
+Environment = OTOBO_HOME=/opt/otobo
+Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
+Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart = /opt/otobo/bin/otobo.Daemon.pl start
+ExecStop = /opt/otobo/bin/otobo.Daemon.pl stop
+RestartSec = 5min
+Restart = always
+
+[Install]
+WantedBy = multi-user.target

--- a/var/systemd/otobo-web.service
+++ b/var/systemd/otobo-web.service
@@ -1,0 +1,18 @@
+[Unit]
+Description = Otobo Web Service
+Documentation = https://doc.otobo.org
+After = network.target
+
+[Service]
+Type = simple
+User = otobo
+Group = otobo
+WorkingDirectory = /opt/otobo
+Environment = OTOBO_HOME=/opt/otobo
+Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
+Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart = /opt/otobo/bin/docker/entrypoint.sh web
+Restart = always
+
+[Install]
+WantedBy = multi-user.target


### PR DESCRIPTION
This PR includes all configuration files and changes to support a native installation of OTOBO 11.x. Tested on RHEL 9.7 but might also work in different versions.

The following changes have been made:
- Create nginx config files for ssl and non-ssl reverse proxy support
- Include `nginx` user group in `bin/otobo.SetPermissions.pl`
- Create `cpanfile.plackup` for all required perl packages on RHEL 9.7 (removed optional options for gazelle and mysql) 
- Create `scripts/build-rhel-modules.sh` to automate the deployment of the required perl packages to a tar.gz file
- Create systemunit files for `otobo-web` and `otobo-daemon` (The service will be controlled using systemctl)

The build script has also been tested on the `redhat/ubi9:9.7` docker image to provide the opportunity for a deployment using Github Actions or Gitlab CI.

A complete documentation of the installation process has been created under https://github.com/RotherOSS/doc-otobo-installation/tree/issue-%23151-rhel.