### PR TITLE
Use greedy but more restrictive regex  for blockquote HTML processing

### DIFF
--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -135,7 +135,7 @@ sub ToAscii {
     my %Cite;
     $Counter = 0;
     $Param{String} =~ s{
-        <blockquote(.*?)>(.+?)</blockquote>
+        <blockquote([^>]*)>(.+?)</blockquote>
     }
     {
         my $Ascii = $Self->ToAscii(


### PR DESCRIPTION
Our OTOBO instance ran into a problem where the MailFetch cron was just timing out every time

Use of `perl bin/otobo.Console.pl Maint::PostMaster::MailAccountFetch --force-pid --debug` and many print statements later (I'm sure there must be a better way of debugging, but I don't know it), I narrowed the issue down to the `blockquote` processing section of `Kernel::System::HTMLUtils::ToAscii`

I figured the `.*?` capture group looked suspicious, so swapped it out with `[^>]*` and suddenly everything processed quickly. All fixed, time for a PR.

(I'm sure I was told not to use regex to parse HTML [s̴̰͊ö̵̺́m̵̝̂e̵̢̛w̶͉̒h̶̞̎e̵͓̔r̵̟͐e̸͈̕](https://stackoverflow.com/a/1732454/995325)   ;-))

I don't know exactly what was in the email body to cause such an issue (the email itself was "only" 700kB in size including attachments), but this seems better anyway

(shout at me if you'd like a corresponding issue)