### PR TITLE
Issue #1860: remove an already commented out code block

### DIFF
--- a/Kernel/System/DB/mysql.pm
+++ b/Kernel/System/DB/mysql.pm
@@ -92,12 +92,6 @@ sub LoadPreferences {
 
     #$Self->{'DB::ShellConnect'} = '';
 
-    # init sql setting on db connect
-    # TODO: test whether this is needed for MySQL
-    #if ( !$Kernel::OM->Get('Kernel::Config')->Get('Database::ShellOutput') ) {
-    #    $Self->{'DB::Connect'} = 'SET NAMES utf8mb4';
-    #}
-
     return 1;
 }
 


### PR DESCRIPTION
Running 'SET NAMES utf8mb4' when connecting to a database is not needed when connecting with DBD::MariaDB