### PR TITLE
Remove unused perl modules & optimize build script

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -228,11 +228,9 @@ my %IsPlackupFeature = (
     'gazelle'            => 1,
     'performance:redis'  => 1,
     'db:odbc'            => 1,
-    'db:oracle'          => 1,
     'db:postgresql'      => 1,
     'db:sqlite'          => 1,
     'div:xslt'           => 1,
-    'div:qrcode'         => 1,
     'div:cldr'           => 1,
     'graph:graphviz'     => 1,
 );

--- a/cpanfile.plackup
+++ b/cpanfile.plackup
@@ -134,11 +134,8 @@ requires 'Plack::Middleware::ReverseProxy';
 
 # };
 
-# feature 'db:oracle', 'Support for database Oracle' => sub {
-    # Required to connect to a Oracle database.
-    requires 'DBD::Oracle';
+# Feature 'db:oracle' is not needed
 
-# };
 
 # feature 'db:postgresql', 'Support for database PostgreSQL' => sub {
     # Required to connect to a PostgreSQL database.
@@ -221,11 +218,8 @@ requires 'Plack::Middleware::ReverseProxy';
 
 # };
 
-# feature 'div:qrcode', 'Support for feature div:qrcode' => sub {
-    # Support for QR code in PDF files
-    requires 'Text::QRCode';
+# Feature 'div:qrcode' is not needed
 
-# };
 
 # feature 'div:xslt', 'Support for feature div:xslt' => sub {
     # Required for Generic Interface XSLT mapping module.

--- a/scripts/tools/build-rhel-modules.sh
+++ b/scripts/tools/build-rhel-modules.sh
@@ -53,7 +53,7 @@ cp cpanfile.plackup cpanfile -f
 
 if [ -f "cpanfile" ]; then
     echo "Installing dependencies to $TARGET_LIB..."
-    cpanm --local-lib "$TARGET_LIB" --self-contained --notest --installdeps .
+    cpanm --local-lib "$TARGET_LIB" --self-contained --notest --mirror "http://www.cpan.org" --mirror-only --installdeps .
 else
     echo "Error: Couldn't find cpanfile in $PROJECT_ROOT!"
     exit 1


### PR DESCRIPTION
- Remove unused perl packages from CheckModules.pl due to compatibilitz issues
- Explicitly require cpanm default mirror for building perl modules. This makes the build process clearly faster