### PR TITLE
Issue #5179: do not consider the parameter 'Type'

### DIFF
--- a/Kernel/System/Main.pm
+++ b/Kernel/System/Main.pm
@@ -828,7 +828,7 @@ sub GetReleaseInfo {
         # filename clean up
         $Param{Filename} = $Self->FilenameCleanUp(
             Filename => $Param{Filename},
-            Type     => $Param{Type} || 'Local',    # Local|Attachment|MD5
+            Type     => 'Local',
         );
         $Param{Location} = "$Param{Directory}/$Param{Filename}";
     }


### PR DESCRIPTION
always pass 'Local' as the type to FileNameCleanup()