### PR TITLE
Issue #5188: remove AdminCloudServices from navigation

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -6582,7 +6582,7 @@ via the Preferences button after logging in.
             </Array>
         </Value>
     </Setting>
-    <Setting Name="Frontend::NavigationModule###AdminCloudServices" Required="0" Valid="1">
+    <Setting Name="Frontend::NavigationModule###AdminCloudServices" Required="0" Valid="0">
         <Description Translatable="1">Admin area navigation for the agent interface.</Description>
         <Navigation>Frontend::Admin::ModuleRegistration::AdminOverview</Navigation>
         <Value>


### PR DESCRIPTION
This means that AdminCloudServices will no longer show up in the Admin overview.
The frontend module can still be opened directly.