### PR TITLE
Add advanced settings to agent personal perferences

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -3712,7 +3712,7 @@ You can log in via the following URL:
             <Item ValueType="String" ValueRegex="">http://host.example.com/cgi-bin/login.pl</Item>
         </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###1-GoogleMaps" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Frontend::CustomerUser::Item###1-GoogleMaps" Required="0" Valid="1">
         <Description Translatable="1">Defines a customer item, which generates a google maps icon at the end of a customer info block.</Description>
         <Navigation>Frontend::Customer</Navigation>
         <Value>
@@ -3729,7 +3729,7 @@ You can log in via the following URL:
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###2-Google" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="0">
+    <Setting Name="Frontend::CustomerUser::Item###2-Google" Required="0" Valid="0">
         <Description Translatable="1">Defines a customer item, which generates a google icon at the end of a customer info block.</Description>
         <Navigation>Frontend::Customer</Navigation>
         <Value>
@@ -3746,7 +3746,7 @@ You can log in via the following URL:
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###2-LinkedIn" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="0">
+    <Setting Name="Frontend::CustomerUser::Item###2-LinkedIn" Required="0" Valid="0">
         <Description Translatable="1">Defines a customer item, which generates a LinkedIn icon at the end of a customer info block.</Description>
         <Navigation>Frontend::Customer</Navigation>
         <Value>
@@ -3763,7 +3763,7 @@ You can log in via the following URL:
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###3-XING" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="0">
+    <Setting Name="Frontend::CustomerUser::Item###3-XING" Required="0" Valid="0">
         <Description Translatable="1">Defines a customer item, which generates a XING icon at the end of a customer info block.</Description>
         <Navigation>Frontend::Customer</Navigation>
         <Value>
@@ -9565,6 +9565,15 @@ via the Preferences button after logging in.
                         <Item Key="Description" Translatable="1">Tweak the system as you wish.</Item>
                         <Item Key="Icon">fa-cog</Item>
                         <Item Key="Prio">1002</Item>
+                    </Hash>
+                </Item>
+                <Item>
+                    <Hash>
+                        <Item Key="Key">Advanced</Item>
+                        <Item Key="Name" Translatable="1">Advanced</Item>
+                        <Item Key="Description" Translatable="1">Advanced settings for efficient work.</Item>
+                        <Item Key="Icon">fa-gears</Item>
+                        <Item Key="Prio">1003</Item>
                     </Hash>
                 </Item>
             </Array>

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -5825,7 +5825,7 @@
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###15-OpenTickets" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Frontend::CustomerUser::Item###15-OpenTickets" Required="0" Valid="1">
         <Description Translatable="1">Customer item (icon) which shows the open tickets of this customer as info block. Setting CustomerUserLogin to 1 searches for tickets based on login name rather than CustomerID.</Description>
         <Navigation>Frontend::Customer</Navigation>
             <Value>
@@ -5845,7 +5845,7 @@
                 </Hash>
             </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###16-OpenTicketsForCustomerUserLogin" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Frontend::CustomerUser::Item###16-OpenTicketsForCustomerUserLogin" Required="0" Valid="1">
         <Description Translatable="1">Customer item (icon) which shows the open tickets of this customer as info block. Setting CustomerUserLogin to 1 searches for tickets based on login name rather than CustomerID.</Description>
         <Navigation>Frontend::Customer</Navigation>
             <Value>
@@ -5865,7 +5865,7 @@
                 </Hash>
             </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###17-ClosedTickets" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Frontend::CustomerUser::Item###17-ClosedTickets" Required="0" Valid="1">
         <Description Translatable="1">Customer item (icon) which shows the closed tickets of this customer as info block. Setting CustomerUserLogin to 1 searches for tickets based on login name rather than CustomerID.</Description>
         <Navigation>Frontend::Customer</Navigation>
             <Value>
@@ -5885,7 +5885,7 @@
                 </Hash>
             </Value>
     </Setting>
-    <Setting Name="Frontend::CustomerUser::Item###18-ClosedTicketsForCustomerUserLogin" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Frontend::CustomerUser::Item###18-ClosedTicketsForCustomerUserLogin" Required="0" Valid="1">
         <Description Translatable="1">Customer item (icon) which shows the closed tickets of this customer as info block. Setting CustomerUserLogin to 1 searches for tickets based on login name rather than CustomerID.</Description>
         <Navigation>Frontend::Customer</Navigation>
             <Value>
@@ -8138,7 +8138,7 @@
             <Item ValueType="String" Translatable="1">Support Agent</Item>
         </Value>
     </Setting>
-    <Setting Name="Ticket::Frontend::CustomerTicketZoom###TicketInfoDisplayType" UserPreferencesGroup="Advanced" UserModificationActive="1" UserModificationPossible="1" Required="0" Valid="1">
+    <Setting Name="Ticket::Frontend::CustomerTicketZoom###TicketInfoDisplayType" Required="0" Valid="1">
         <Description Translatable="1">Defines if the ticket info widget is displayed permanently on the left below the article list or is available via click on the 'Information' button.</Description>
         <Navigation>Frontend::Customer::View::TicketZoom</Navigation>
         <Value>


### PR DESCRIPTION
**New feature:** advanced settings in agent personal preferences.

This feature allows agents to change more settings in their personal preferences. A new section called "Advanced" is displayed where agents can fine tune some settings related to agent interface.

The logic of this feature came from ((OTRS)) Community Edition, but the switch was part of Business Solution package. This means that an expert agent already had the possibility to activate this feature in the system, but it was not activated by default - only for Business Solution customers.

Since this can be considered as "new feature", I create this pull request against `rel-11_1` only. The logic is also part of the previous versions, so feel free to back-port this feature to `rel-11_0` and `rel-10_1` if you think, it would be useful for current customers. This change is backward compatible.

Thanks to [László Gyaraki](https://github.com/gyarakilaszlo) to find the way how to activate this feature.