### PR TITLE
Issue #5215: change issue ticket to create ticket in customer interface

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
@@ -15,7 +15,7 @@
 # --
 <div id="oooContent" class="ARIARoleMain TicketCompose">
     <div id="oooHeader">
-        <h1>[% Translate("Issue a new Ticket") | html %]</h1>
+        <h1>[% Translate("Create a new Ticket") | html %]</h1>
     </div>
     <div id="oooMainBox" class="Content">
         <form action="[% Env("CGIHandle") %]" method="post" name="compose" id="NewCustomerTicket" enctype="multipart/form-data" class="Validate PreventMultipleSubmits">

--- a/Kernel/Output/HTML/Templates/Standard/Dashboard/TileNewTicket.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Dashboard/TileNewTicket.tt
@@ -14,6 +14,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 # --
 <a id="oooTile[% Data.TileID | html %]" class="oooTile oooTile_NewTicket" href="[% Env("Baselink") %]Action=CustomerTicketMessage">
-    <h1 style="color: [% Data.Color | html %]">[% Translate("Issue%sa ticket") | html | ReplacePlaceholders('<br/>') %]</h1>
+    <h1 style="color: [% Data.Color | html %]">[% Translate("Create%sa ticket") | html | ReplacePlaceholders('<br/>') %]</h1>
     <h1 style="color: [% Data.Color | html %]"><i class="ooofo ooofo-add"></i></h1>
 </a>


### PR DESCRIPTION
Changed the term _Issue Ticket_ to _Create Ticket_ to be consistent with other parts of the user interface.

As discussed in the relevant issue, this change is only for OTOBO 11.1.

Fixes #5215 