### PR TITLE
Issue #5231: add ticket mark seen/unseen action to ACL editor

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -12165,6 +12165,7 @@
                 <Item>AgentTicketHistory</Item>
                 <Item>AgentTicketLink</Item>
                 <Item>AgentTicketLock</Item>
+                <Item>AgentTicketMarkSeenUnseen</Item>
                 <Item>AgentTicketMerge</Item>
                 <Item>AgentTicketMove</Item>
                 <Item>AgentTicketNote</Item>


### PR DESCRIPTION
This PR adds the missing `AgentTicketMarkSeenUnseen` entry to be available for _Action_ in third level of the ACL structure.

Thanks to [László Gyaraki](https://github.com/gyarakilaszlo) for finding the issue and providing the possible fix.

Fixes #5231 