### PR TITLE
Issue #5164: Treat dynamic field values as external.

### DIFF
--- a/Kernel/System/PostMaster/FollowUp.pm
+++ b/Kernel/System/PostMaster/FollowUp.pm
@@ -396,6 +396,7 @@ sub Run {
                 ObjectID           => $Param{TicketID},
                 Value              => $GetParam{$Key},
                 UserID             => $Param{InmailUserID},
+                ExternalSource     => 1,
             );
 
             $Self->{CommunicationLogObject}->ObjectLog(
@@ -436,6 +437,7 @@ sub Run {
                         ObjectID           => $Param{TicketID},
                         Value              => $GetParam{$Key},
                         UserID             => $Param{InmailUserID},
+                        ExternalSource     => 1,
                     );
                 }
 
@@ -635,6 +637,7 @@ sub Run {
                 ObjectID           => $ArticleID,
                 Value              => $GetParam{$Key},
                 UserID             => $Param{InmailUserID},
+                ExternalSource     => 1,
             );
 
             $Self->{CommunicationLogObject}->ObjectLog(
@@ -674,6 +677,7 @@ sub Run {
                         ObjectID           => $ArticleID,
                         Value              => $GetParam{$Key},
                         UserID             => $Param{InmailUserID},
+                        ExternalSource     => 1,
                     );
                 }
 

--- a/Kernel/System/PostMaster/NewTicket.pm
+++ b/Kernel/System/PostMaster/NewTicket.pm
@@ -439,6 +439,7 @@ END_MESSAGE
                 ObjectID           => $TicketID,
                 Value              => $GetParam{$Key},
                 UserID             => $Param{InmailUserID},
+                ExternalSource     => 1,
             );
 
             $Self->{CommunicationLogObject}->ObjectLog(
@@ -479,6 +480,7 @@ END_MESSAGE
                         ObjectID           => $TicketID,
                         Value              => $GetParam{$Key},
                         UserID             => $Param{InmailUserID},
+                        ExternalSource     => 1,
                     );
                 }
 
@@ -694,6 +696,7 @@ END_MESSAGE
                 ObjectID           => $ArticleID,
                 Value              => $GetParam{$Key},
                 UserID             => $Param{InmailUserID},
+                ExternalSource     => 1,
             );
 
             $Self->{CommunicationLogObject}->ObjectLog(
@@ -734,6 +737,7 @@ END_MESSAGE
                         ObjectID           => $ArticleID,
                         Value              => $GetParam{$Key},
                         UserID             => $Param{InmailUserID},
+                        ExternalSource     => 1,
                     );
                 }
 


### PR DESCRIPTION
In postmaster filters, dynamic field values should be treated as external source.

closes #5164