### PR TITLE
Issue #4959: Added configurable masking to webservice debugger.

### DIFF
--- a/Kernel/Config/Files/XML/GenericInterface.xml
+++ b/Kernel/Config/Files/XML/GenericInterface.xml
@@ -1155,8 +1155,8 @@
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="GenericInterface::Debugger::Settings::MaskParameter" Required="0" Valid="1">
-        <Description Translatable="1">Define names of sensitive parameter for which the content should be masked in the debugger (e.g. credentials). Note: The masking won't affect previously logged data, it only takes effect for future requests.</Description>
+    <Setting Name="GenericInterface::Debugger::Settings::RedactParameter" Required="0" Valid="1">
+        <Description Translatable="1">Define names of sensitive parameters. Their contents will be redacted in the debugger (for example, credentials). Note: Redaction will not affect previously logged data, it only takes effect for future requests.</Description>
         <Navigation>GenericInterface::Debugger::Settings</Navigation>
         <Value>
             <Array>

--- a/Kernel/Config/Files/XML/GenericInterface.xml
+++ b/Kernel/Config/Files/XML/GenericInterface.xml
@@ -1155,4 +1155,13 @@
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="GenericInterface::Debugger::Settings::MaskParameter" Required="0" Valid="1">
+        <Description Translatable="1">Define names of sensitive parameter for which the content should be masked in the debugger (e.g. credentials). Note: The masking won't affect previously logged data, it only takes effect for future requests.</Description>
+        <Navigation>GenericInterface::Debugger::Settings</Navigation>
+        <Value>
+            <Array>
+                <Item>Password</Item>
+            </Array>
+        </Value>
+    </Setting>
 </otobo_config>

--- a/Kernel/GenericInterface/Debugger.pm
+++ b/Kernel/GenericInterface/Debugger.pm
@@ -208,10 +208,10 @@ sub DebugLog {
     }
 
     # mask configured attributes
-    my $BlackListedParams = $Kernel::OM->Get('Kernel::Config')->Get('GenericInterface::Debugger::Settings::MaskParameter') // [];
-    for my $MaskParam ( $BlackListedParams->@* ) {
-        $DataString =~ s/"$MaskParam":(\s*)".+?"(,|\n|\})/"$MaskParam":$1"xxx"$2/g;
-        $DataString =~ s/'$MaskParam' =\> '.+?'(,|\n|\})/'$MaskParam => 'xxx'$1/g;
+    my $BlackListedParams = $Kernel::OM->Get('Kernel::Config')->Get('GenericInterface::Debugger::Settings::RedactParameter') // [];
+    for my $RedactParam ( $BlackListedParams->@* ) {
+        $DataString =~ s/"$RedactParam":(\s*)".+?"(,|\n|\})/"$RedactParam":$1"xxx"$2/g;
+        $DataString =~ s/'$RedactParam' =\> '.+?'(,|\n|\})/'$RedactParam => 'xxx'$1/g;
     }
 
     if ( !$Self->{TestMode} ) {

--- a/Kernel/GenericInterface/Debugger.pm
+++ b/Kernel/GenericInterface/Debugger.pm
@@ -207,6 +207,13 @@ sub DebugLog {
         $DataString = 'No data provided';
     }
 
+    # mask configured attributes
+    my $BlackListedParams = $Kernel::OM->Get('Kernel::Config')->Get('GenericInterface::Debugger::Settings::MaskParameter') // [];
+    for my $MaskParam ( $BlackListedParams->@* ) {
+        $DataString =~ s/"$MaskParam":(\s*)".+?"(,|\n|\})/"$MaskParam":$1"xxx"$2/g;
+        $DataString =~ s/'$MaskParam' =\> '.+?'(,|\n|\})/'$MaskParam => 'xxx'$1/g;
+    }
+
     if ( !$Self->{TestMode} ) {
 
         if ( $DebugLevels{ $Param{DebugLevel} } >= $DebugLevels{ $Self->{DebugThreshold} } ) {


### PR DESCRIPTION
Content of configured set of attributes is now masked in the webservice debugger. Configuration can be changed via a new sysconfig setting.

closes #4959