### PR TITLE
Issue #5265: Break long df labels when they exceed the container.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
@@ -45,6 +45,7 @@ ul.Tablelike li {
     padding: 0 4px;
     min-height: 20px;
     background-color: #FFF;
+    overflow-wrap: break-word;
 }
 
 ul.Tablelike li.OneRow,


### PR DESCRIPTION
closes #5265