### PR TITLE
Issue #5273: Fixed attribute name in setting.

### DIFF
--- a/Kernel/System/DynamicField/Driver/CustomerUser.pm
+++ b/Kernel/System/DynamicField/Driver/CustomerUser.pm
@@ -159,8 +159,8 @@ sub GetFieldTypeSettings {
             Explanation     => Translatable('When set via an external source (e.g. web service or import / export), the value will be interpreted as this attribute.'),
             InputType       => 'Selection',
             SelectionData   => {
-                'UserLogin' => 'Login',
-                'UserEmail' => 'E-Mail',
+                'UserLogin'        => 'Login',
+                'PostMasterSearch' => 'E-Mail',
             },
             PossibleNone => 1,
             Multiple     => 0,


### PR DESCRIPTION
The name PostMasterSearch is important because the CustomerSearch needs to perform a PostMasterSearch in case of e-mail as search attribute.

closes #5273