### PR TITLE
Issue #5275: Removed erroneous return statement.

### DIFF
--- a/Kernel/System/DynamicField/Driver/CustomerUser.pm
+++ b/Kernel/System/DynamicField/Driver/CustomerUser.pm
@@ -38,9 +38,9 @@ use Kernel::System::VariableCheck qw(IsArrayRefWithData IsHashRefWithData);
 our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::CustomerUser',
-    'Kernel::System::Group',
     'Kernel::System::DynamicField',
     'Kernel::System::DynamicField::Backend',
+    'Kernel::System::Group',
     'Kernel::System::Log',
 );
 

--- a/Kernel/System/DynamicField/Driver/CustomerUser.pm
+++ b/Kernel/System/DynamicField/Driver/CustomerUser.pm
@@ -458,8 +458,6 @@ sub _GetHTTPLink {
                 $AccessRo = 1;
             }
         }
-
-        return;
     }
 
     if ( $AccessRo || $AccessRw ) {


### PR DESCRIPTION
This prevented link creation if entries were present in Group and / or
GroupRo attributes of sysconfig setting
Frontend::Module###AgentCustomerUserInformationCenter.

closes #5275