### PR TITLE
Issue #5300: Mapped CustomerUserID to CustomerUserLogin.

### DIFF
--- a/Kernel/System/DynamicField/Driver/Ticket.pm
+++ b/Kernel/System/DynamicField/Driver/Ticket.pm
@@ -491,6 +491,10 @@ sub SearchObjects {
                     };
                 }
 
+                elsif ( $FilterItem->{ReferenceObjectAttribute} eq 'CustomerUserID' ) {
+                    $SearchParams{CustomerUserLogin} = [$EqualsObjectAttribute];
+                }
+
                 # array attribute
                 else {
                     $SearchParams{$AttributeName} = [$EqualsObjectAttribute];


### PR DESCRIPTION
TicketSearch() uses CustomerUserID to identify a search from a customer user. The appropriate param to restrict for certain customerusers is CustomerUserLogin.

closes #5300