### PR TITLE
Issue #5009: Position error dialogue relative to viewport.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Dialog.css
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
  * @subsection  Dialog
  */
 .Dialog {
-    position: absolute;
+    position: fixed;
     z-index: 6000;
     min-width: 150px;
     background: white;


### PR DESCRIPTION
This is achieved by setting position to fixed, which causes the top value to be calculated relative to the viewport.

closes #5009