### PR TITLE
Add LWP::Protocol::https for OpenIDConnect OIDC support

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -1067,6 +1067,17 @@ my @NeededModules = (
             ports  => undef,
         },
     },
+    {
+        Module    => 'LWP::Protocol::https',
+        Features  => ['auth:openidconnect'],
+        Comment   => 'Required for HTTPS connections to OpenID Connect providers.',
+        InstTypes => {
+            aptget => 'liblwp-protocol-https-perl',
+            emerge => 'dev-perl/LWP-Protocol-https',
+            zypper => 'perl-LWP-Protocol-https',
+            ports  => 'www/p5-LWP-Protocol-https',
+        },
+    },
 
     # Feature div
     {

--- a/cpanfile
+++ b/cpanfile
@@ -119,6 +119,9 @@ feature 'auth:openidconnect', 'Support for feature auth:openidconnect' => sub {
     # Required for authentication via OpenIDConnect.
     requires 'Crypt::JWT';
 
+    # Required for HTTPS connections to OpenID Connect providers.
+    requires 'LWP::Protocol::https';
+
 };
 
 feature 'db:mysql', 'Support for database MySQL' => sub {
@@ -390,6 +393,9 @@ feature 'optional', 'Support for feature optional' => sub {
 
     # Required for authentication via OpenIDConnect.
     requires 'Crypt::JWT';
+
+    # Required for HTTPS connections to OpenID Connect providers.
+    requires 'LWP::Protocol::https';
 
     # Required to handle mails with several Chinese character sets.
     requires 'Encode::HanExtra', '>= 0.23';

--- a/cpanfile.docker
+++ b/cpanfile.docker
@@ -116,6 +116,9 @@ requires 'Plack::Middleware::ReverseProxy';
     # Required for authentication via OpenIDConnect.
     requires 'Crypt::JWT';
 
+    # Required for HTTPS connections to OpenID Connect providers.
+    requires 'LWP::Protocol::https';
+
 # };
 
 # feature 'db:mysql', 'Support for database MySQL' => sub {

--- a/cpanfile.plackup
+++ b/cpanfile.plackup
@@ -116,6 +116,9 @@ requires 'Plack::Middleware::ReverseProxy';
     # Required for authentication via OpenIDConnect.
     requires 'Crypt::JWT';
 
+    # Required for HTTPS connections to OpenID Connect providers.
+    requires 'LWP::Protocol::https';
+
 # };
 
 # feature 'db:mysql', 'Support for database MySQL' => sub {
@@ -232,6 +235,9 @@ requires 'Plack::Middleware::ReverseProxy';
     requires 'XML::LibXSLT';
 
 # };
+
+# Feature 'div:zlib' is not needed
+
 
 # feature 'gazelle', 'Required packages if you want to use Gazelle webserver' => sub {
     # High-performance preforking PSGI/Plack web server


### PR DESCRIPTION
The OpenIDConnect authentication module uses LWP::UserAgent to fetch the OIDC provider's .well-known/openid-configuration endpoint. When the provider uses HTTPS (standard for Keycloak, Auth0, Azure AD, etc.), the request fails with '501 Protocol scheme https is not supported' because LWP::Protocol::https is not installed.

Added as a dependency of the auth:openidconnect feature alongside the existing Crypt::JWT requirement.