### PR TITLE
Tidied.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminAppointmentCalendarManage.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminAppointmentCalendarManage.tt
@@ -107,7 +107,7 @@
             </div>
             <div class="Content">
                 <p class="FieldExplanation">
-                    [% Translate("Here you can upload a configuration file to import a calendar to your system. The file needs to be in .yml format as exported by calendar management module.") | html %]
+                    [% Translate("Here you can upload a configuration file to import a calendar to your system. The file needs to be in .yml format as exported by the calendar management module.") | html %]
                 </p>
                 <ul class="ActionList SpacingTop">
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldAdvanced.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldAdvanced.tt
@@ -32,7 +32,7 @@
 
     <div class='Content'>
         <p class='FieldExplanation'>
-            [% Translate('Here you can upload a configuration file to import dynamic fields to your system. The file needs to be in .yml format as exported by dynamic field management module.') | html %]
+            [% Translate('Here you can upload a configuration file to import dynamic fields to your system. The file needs to be in .yml format as exported by the dynamic field management module.') | html %]
         </p>
         <ul class='ActionList SpacingTop'>
             <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -102,7 +102,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import generic agents to your system. The file needs to be in .yml format as exported by generic agent management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import generic agents to your system. The file needs to be in .yml format as exported by the generic agent management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGroup.tt
@@ -116,7 +116,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import groups to your system. The file needs to be in .yml format as exported by group management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import groups to your system. The file needs to be in .yml format as exported by the group management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
@@ -66,7 +66,7 @@
             </div>
             <div class="Content">
                 <p class="FieldExplanation">
-                    [% Translate("Here you can upload a configuration file to import a process to your system. The file needs to be in .yml format as exported by process management module.") | html %]
+                    [% Translate("Here you can upload a configuration file to import a process to your system. The file needs to be in .yml format as exported by the process management module.") | html %]
                 </p>
                 <ul class="ActionList SpacingTop">
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
@@ -104,7 +104,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import queues to your system. The file needs to be in .yml format as exported by queue management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import queues to your system. The file needs to be in .yml format as exported by the queue management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplates.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplates.tt
@@ -103,7 +103,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import queue-template relations to your system. The file needs to be in .yml format as exported by queue-template management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import queue-template relations to your system. The file needs to be in .yml format as exported by the queue-template management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRole.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRole.tt
@@ -111,7 +111,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import roles to your system. The file needs to be in .yml format as exported by role management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import roles to your system. The file needs to be in .yml format as exported by the role management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleGroup.tt
@@ -88,7 +88,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import role-group relations to your system. The file needs to be in .yml format as exported by role-group management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import role-group relations to your system. The file needs to be in .yml format as exported by the role-group management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
@@ -104,7 +104,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import SLAs to your system. The file needs to be in .yml format as exported by SLA management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import SLAs to your system. The file needs to be in .yml format as exported by the SLA management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminService.tt
@@ -99,7 +99,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import services to your system. The file needs to be in .yml format as exported by queue management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import services to your system. The file needs to be in .yml format as exported by the service management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplate.tt
@@ -112,7 +112,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import templates to your system. The file needs to be in .yml format as exported by template management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import templates to your system. The file needs to be in .yml format as exported by the template management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>

--- a/Kernel/Output/HTML/Templates/Standard/AdminType.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminType.tt
@@ -102,7 +102,7 @@
 
             <div class='Content'>
                 <p class='FieldExplanation'>
-                    [% Translate('Here you can upload a configuration file to import types to your system. The file needs to be in .yml format as exported by type management module.') | html %]
+                    [% Translate('Here you can upload a configuration file to import types to your system. The file needs to be in .yml format as exported by the type management module.') | html %]
                 </p>
                 <ul class='ActionList SpacingTop'>
                     <li>


### PR DESCRIPTION
Improved wording by adding proper article to noun. Also included a fix for 'queue' -> 'service'.

Motivated by https://github.com/RotherOSS/servicecatalog/issues/17 - thanks to @StefanAbel-OTOBO!