### PR TITLE
Tidied.

### DIFF
--- a/Kernel/System/DynamicField/Driver/Agent.pm
+++ b/Kernel/System/DynamicField/Driver/Agent.pm
@@ -116,7 +116,7 @@ sub GetFieldTypeSettings {
         {
             ConfigParamName => 'Group',
             Label           => Translatable('Group of the agents'),
-            Explanation     => Translatable('Select the group of the agents'),
+            Explanation     => Translatable('Select the group of the agents.'),
             InputType       => 'Selection',
             SelectionData   => \%GroupList,
             PossibleNone    => 1,

--- a/Kernel/System/DynamicField/Driver/BaseReference.pm
+++ b/Kernel/System/DynamicField/Driver/BaseReference.pm
@@ -995,7 +995,7 @@ sub GetFieldTypeSettings {
             {
                 ConfigParamName => 'ReferencedObjectType',
                 Label           => Translatable('Referenced object type'),
-                Explanation     => Translatable('Select the type of the referenced object'),
+                Explanation     => Translatable('Select the type of the referenced object.'),
                 InputType       => 'Selection',
                 SelectionData   => { $Self->{ReferencedObjectType} => $Self->{ReferencedObjectType} },
                 PossibleNone    => 0,

--- a/Kernel/System/DynamicField/Driver/CustomerCompany.pm
+++ b/Kernel/System/DynamicField/Driver/CustomerCompany.pm
@@ -114,7 +114,7 @@ sub GetFieldTypeSettings {
         {
             ConfigParamName => 'SearchAttribute',
             Label           => Translatable('Attribute which will be searched on autocomplete'),
-            Explanation     => Translatable('Select the attribute which customer companies will be searched by'),
+            Explanation     => Translatable('Select the attribute which customer companies will be searched by.'),
             InputType       => 'Selection',
             SelectionData   => {
                 'CustomerID'          => 'Customer ID',

--- a/Kernel/System/DynamicField/Driver/CustomerUser.pm
+++ b/Kernel/System/DynamicField/Driver/CustomerUser.pm
@@ -194,7 +194,7 @@ sub GetFieldTypeSettings {
             {
                 ConfigParamName => 'ReferencedObjectType',
                 Label           => Translatable('Referenced object type'),
-                Explanation     => Translatable('Select the type of the referenced object'),
+                Explanation     => Translatable('Select the type of the referenced object.'),
                 InputType       => 'Selection',
                 SelectionData   => { $Self->{ReferencedObjectType} => $Self->{ReferencedObjectType} },
                 PossibleNone    => 0,

--- a/Kernel/System/DynamicField/Driver/Ticket.pm
+++ b/Kernel/System/DynamicField/Driver/Ticket.pm
@@ -117,7 +117,7 @@ sub GetFieldTypeSettings {
         {
             ConfigParamName => 'Queue',
             Label           => Translatable('Queue of the ticket'),
-            Explanation     => Translatable('Select the queue of the ticket'),
+            Explanation     => Translatable('Select the queue of the ticket.'),
             InputType       => 'Selection',
             SelectionData   => \%QueueID2Name,
             PossibleNone    => 1,
@@ -132,7 +132,7 @@ sub GetFieldTypeSettings {
             {
                 ConfigParamName => 'TicketType',
                 Label           => Translatable('Type of the ticket'),
-                Explanation     => Translatable('Select the type of the ticket'),
+                Explanation     => Translatable('Select the type of the ticket.'),
                 InputType       => 'Selection',
                 SelectionData   => \%TypeID2Name,
                 PossibleNone    => 1,
@@ -145,7 +145,7 @@ sub GetFieldTypeSettings {
         {
             ConfigParamName => 'SearchAttribute',
             Label           => Translatable('Attribute which will be searched on autocomplete'),
-            Explanation     => Translatable('Select the attribute which tickets will be searched by'),
+            Explanation     => Translatable('Select the attribute which tickets will be searched by.'),
             InputType       => 'Selection',
             SelectionData   => {
                 'TicketNumber' => 'TicketNumber',
@@ -174,7 +174,7 @@ sub GetFieldTypeSettings {
         {
             ConfigParamName => 'DisplayType',
             Label           => Translatable('Attribute which is displayed for values'),
-            Explanation     => Translatable('Select the type of display'),
+            Explanation     => Translatable('Select the type of display.'),
             InputType       => 'Selection',
             SelectionData   => {
                 'TicketNumber'      => 'Ticket#<Ticket Number>',


### PR DESCRIPTION
Always end explanation sentences with a dot.

Also fixed a comparison operator mismatch.