### PR TITLE
Issue #4427: update the base Docker image for the elastic image

### DIFF
--- a/otobo.elasticsearch.dockerfile
+++ b/otobo.elasticsearch.dockerfile
@@ -5,17 +5,7 @@
 
 # Use 7.17.27, because latest flag is not available
 # It is currently unclear un which OS the image is based. The User is root.
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.27 AS otobo-elasticsearch
-
-# Install system tools
-# Hadolint ignore=DL3008
-RUN apt-get update \
- && apt-get -y --no-install-recommends install -y\
- "less"\
- "nano"\
- "tree"\
- "vim"\
- && rm -rf /var/lib/apt/lists/*
+FROM elasticsearch:8.19.3 AS otobo-elasticsearch
 
 # Install important plugins
 RUN bin/elasticsearch-plugin install --batch ingest-attachment


### PR DESCRIPTION
- pull the image from Docker Hub, in order to simplify Github actions
- upgrade Elasticsearch from 7.17.27 to 8.19.3
- do not install system tools as Docker build complained about them