### PR TITLE
Issue #5398: Unified CSS for spans and anchors in table headers.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
@@ -342,7 +342,8 @@ td.Attachment {
     border-right: 0px;
 }
 
-.TableSmall thead th a {
+.TableSmall thead th a,
+.TableSmall thead th span.Gray {
     padding-top: 2px;
     padding-bottom: 2px;
 }
@@ -704,7 +705,8 @@ thead .tablesorter-headerAsc > div.tablesorter-header-inner > a:before {
 
 .DataTable thead th.DashboardHeader a,
 .TableSmall thead th.OverviewHeader a,
-.DataTable thead th.DashboardHeader span.Gray {
+.DataTable thead th.DashboardHeader span.Gray,
+.TableSmall thead th.OverviewHeader span.Gray {
     height: 16px;
     line-height: 16px;
     padding-left: 5px;


### PR DESCRIPTION
Screenshot with modification in place:

<img width="1902" height="147" alt="Bildschirmfoto_20260416_084644" src="https://github.com/user-attachments/assets/10f64b98-a4eb-4459-86c2-09926b9500ab" />

closes #5398