### PR TITLE
Build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/actions/docker_image_builder/action.yml
+++ b/.github/actions/docker_image_builder/action.yml
@@ -60,7 +60,7 @@ runs:
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       -
         name: Set up Docker Buildx

--- a/.github/actions/docker_image_builder/action.yml
+++ b/.github/actions/docker_image_builder/action.yml
@@ -29,6 +29,14 @@ inputs:
       List of tags under which the new Docker image should be available on Docker hub.
     required: true
 
+  platforms:
+    description: |
+      Comma-separated list of target platforms for the Docker image, e.g. 'linux/amd64,linux/arm64'.
+      The Build step (with load) always builds for the runner platform only (for sanity checking).
+      The Push step builds and pushes for all specified platforms.
+    required: false
+    default: 'linux/amd64'
+
 #outputs:
 
 runs:
@@ -49,6 +57,10 @@ runs:
         env:
           ENV_AS_JSON:    ${{ toJSON(env) }}
           GITHUB_AS_JSON: ${{ toJSON(github) }}
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       -
         name: Set up Docker Buildx
@@ -89,10 +101,12 @@ runs:
         # finally upload to DockerHub
         # using the provided dockerhub_tags
         # the built image is already available in the job
+        # When multiple platforms are specified, a manifest list is pushed.
         name: Push to DockerHub
         uses: docker/build-push-action@v7
         with:
           push: true
+          platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           pull: true

--- a/.github/actions/docker_image_update/action.yml
+++ b/.github/actions/docker_image_update/action.yml
@@ -29,6 +29,14 @@ inputs:
       List of tags under which the new Docker image should be available on Docker hub.
     required: true
 
+  platforms:
+    description: |
+      Comma-separated list of target platforms for the Docker image, e.g. 'linux/amd64,linux/arm64'.
+      The Build step (with load) always builds for the runner platform only (for sanity checking).
+      The Push step builds and pushes for all specified platforms.
+    required: false
+    default: 'linux/amd64'
+
 #outputs:
 
 runs:
@@ -49,6 +57,10 @@ runs:
         env:
           ENV_AS_JSON:    ${{ toJSON(env) }}
           GITHUB_AS_JSON: ${{ toJSON(github) }}
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       -
         name: Set up Docker Buildx
@@ -103,10 +115,12 @@ runs:
         # finally upload to DockerHub
         # using the provided dockerhub_tags
         # the built image is already available in the job
+        # When multiple platforms are specified, a manifest list is pushed.
         name: Push to DockerHub
         uses: docker/build-push-action@v7
         with:
           push: true
+          platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           pull: true

--- a/.github/actions/docker_image_update/action.yml
+++ b/.github/actions/docker_image_update/action.yml
@@ -60,7 +60,7 @@ runs:
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       -
         name: Set up Docker Buildx

--- a/.github/workflows/docker_image_builder_devel.yml
+++ b/.github/workflows/docker_image_builder_devel.yml
@@ -34,26 +34,31 @@ jobs:
             dockerfile: 'otobo.web.dockerfile'
             context:    '.'
             repository: 'rotheross/otobo'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-elasticsearch'
             dockerfile: 'otobo.elasticsearch.dockerfile'
             context:    'scripts/elasticsearch'
             repository: 'rotheross/otobo-elasticsearch'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-webproxy'
             dockerfile: 'otobo.nginx.dockerfile'
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-webproxy'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-kerberos-webproxy'
             dockerfile: 'otobo.nginx.dockerfile'
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-kerberos-webproxy'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-selenium-chrome'
             dockerfile: 'otobo.selenium-chrome.dockerfile'
             context:    'scripts/test/sample'
             repository: 'rotheross/otobo-selenium-chrome'
+            platforms:  'linux/amd64'
 
     steps:
 
@@ -115,4 +120,5 @@ jobs:
           dockerfile: ${{ steps.get-dockerfile.outputs.dockerfile }}
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
           dockerhub_tags: ${{ env.otobo_ref }}

--- a/.github/workflows/docker_image_builder_rel.yml
+++ b/.github/workflows/docker_image_builder_rel.yml
@@ -35,26 +35,31 @@ jobs:
             dockerfile: 'otobo.web.dockerfile'
             context:    '.'
             repository: 'rotheross/otobo'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-elasticsearch'
             dockerfile: 'otobo.elasticsearch.dockerfile'
             context:    'scripts/elasticsearch'
             repository: 'rotheross/otobo-elasticsearch'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-webproxy'
             dockerfile: 'otobo.nginx.dockerfile'
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-webproxy'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-kerberos-webproxy'
             dockerfile: 'otobo.nginx.dockerfile'
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-kerberos-webproxy'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-selenium-chrome'
             dockerfile: 'otobo.selenium-chrome.dockerfile'
             context:    'scripts/test/sample'
             repository: 'rotheross/otobo-selenium-chrome'
+            platforms:  'linux/amd64'
 
     steps:
 
@@ -98,4 +103,5 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
           dockerhub_tags: ${{ env.otobo_ref }},"${{ matrix.repository }}:latest-${{ env.major_minor }}","${{ matrix.repository }}:latest-${{ env.major_minor }}-autobuild"

--- a/.github/workflows/docker_image_update_all.yml
+++ b/.github/workflows/docker_image_update_all.yml
@@ -137,6 +137,7 @@ jobs:
             context:    '.'
             repository: 'rotheross/otobo'
             base_image: 'perl:5.40-bookworm'
+            platforms:  'linux/amd64,linux/arm64'
 
           # The base image nginx:mainline-trixie is used since 10.1.17 and 11.0.12.
           # nginx:mainline is used in rel-10_1 up to 10.1.16 and then switched to nginx:mainline-trixie
@@ -146,6 +147,7 @@ jobs:
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-webproxy'
             base_image: 'nginx:mainline-trixie'
+            platforms:  'linux/amd64,linux/arm64'
           # Excluded Docker tags
           #-
           #  target:     'otobo-nginx-webproxy'
@@ -164,6 +166,7 @@ jobs:
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-kerberos-webproxy'
             base_image: 'nginx:mainline-trixie'
+            platforms:  'linux/amd64,linux/arm64'
           # Excluded Docker tags
           #-
           #  target:     'otobo-nginx-kerberos-webproxy'
@@ -192,6 +195,7 @@ jobs:
             context:    'scripts/test/sample'
             repository: 'rotheross/otobo-selenium-chrome'
             base_image: 'selenium/standalone-chrome:141.0-chromedriver-141.0-20251101'
+            platforms:  'linux/amd64'
           -
             target:     'otobo-selenium-chrome'
             docker_tag: 'rel-10_1_15'
@@ -216,6 +220,7 @@ jobs:
             context:    'scripts/elasticsearch'
             repository: 'rotheross/otobo-elasticsearch'
             base_image: 'elasticsearch:8.19.3'
+            platforms:  'linux/amd64,linux/arm64'
 
     steps:
 
@@ -303,6 +308,7 @@ jobs:
           dockerfile: ${{ steps.get-dockerfile.outputs.dockerfile }}
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
           dockerhub_tags: "${{ matrix.repository }}:${{ matrix.docker_tag }}"
 
       - name: 'check out so that the composite action becomes available'

--- a/.github/workflows/docker_image_update_autobuild.yml
+++ b/.github/workflows/docker_image_update_autobuild.yml
@@ -75,6 +75,7 @@ jobs:
             context:    '.'
             repository: 'rotheross/otobo'
             base_image: 'perl:5.40-bookworm'
+            platforms:  'linux/amd64,linux/arm64'
 
           # The base image nginx:mainline-trixie is used since 11.0.12.
           # nginx:mainline is used in rel-10_1 up to 10.1.16 and then switched to nginx:mainline-trixie
@@ -84,6 +85,7 @@ jobs:
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-webproxy'
             base_image: 'nginx:mainline-trixie'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-webproxy'
             docker_tag: 'latest-10_1-autobuild'
@@ -97,6 +99,7 @@ jobs:
             context:    'scripts/nginx'
             repository: 'rotheross/otobo-nginx-kerberos-webproxy'
             base_image: 'nginx:mainline-trixie'
+            platforms:  'linux/amd64,linux/arm64'
           -
             target:     'otobo-nginx-kerberos-webproxy'
             docker_tag: 'latest-10_1-autobuild'
@@ -111,6 +114,7 @@ jobs:
             context:    'scripts/test/sample'
             repository: 'rotheross/otobo-selenium-chrome'
             base_image: 'selenium/standalone-chrome:141.0-chromedriver-141.0-20251101'
+            platforms:  'linux/amd64'
           -
             target:     'otobo-selenium-chrome'
             docker_tag: 'latest-10_1-autobuild'
@@ -124,6 +128,7 @@ jobs:
             context:    'scripts/elasticsearch'
             repository: 'rotheross/otobo-elasticsearch'
             base_image: 'elasticsearch:8.19.3'
+            platforms:  'linux/amd64,linux/arm64'
 
     steps:
 
@@ -194,6 +199,7 @@ jobs:
           dockerfile: ${{ steps.get-dockerfile.outputs.dockerfile }}
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
           dockerhub_tags: "${{ matrix.repository }}:${{ matrix.docker_tag }}"
 
       -


### PR DESCRIPTION
## Summary

- Add `linux/arm64` platform support to all Docker image build and update workflows, producing manifest lists so `docker pull` automatically selects the correct architecture
- Add QEMU emulation setup and a `platforms` input to both composite actions (`docker_image_builder` and `docker_image_update`)
- Keep `otobo-selenium-chrome` as `linux/amd64` only since the upstream `selenium/standalone-chrome` base image does not publish arm64 variants

## Details

All base images already support arm64:

| Base image | arm64 support |
|---|---|
| `perl:5.40-bookworm` | Yes |
| `elasticsearch:8.19.3` | Yes |
| `nginx:mainline-trixie` | Yes |
| `mariadb:lts-noble` | Yes |
| `redis:8-bookworm` | Yes |
| `selenium/standalone-chrome` | **No** (amd64 only) |

The existing Build step with `load: true` remains single-platform for the sanity check (`docker run` inspection). Only the Push step uses the `platforms` input to build and push for all specified architectures.

6 files changed, 52 insertions added. No Dockerfiles were modified.

## Test plan

- [x] `otobo.web.dockerfile` builds successfully for `linux/arm64` (verified locally on Apple Silicon — all Debian packages install, all CPAN modules compile)
- [x] `otobo.elasticsearch.dockerfile` builds successfully for `linux/arm64` (verified locally — both `ingest-attachment` and `analysis-icu` plugins install)
- [x] No architecture-specific logic in any Dockerfile (no `TARGETARCH`, no hardcoded binary downloads)
- [ ] Trigger a CI run to verify the full matrix builds on GitHub Actions runners