### PR TITLE
Issue #5415: Prevent JS warning about item unavailable.

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -662,7 +662,6 @@
                 <Item>
                     <Array>
                         <Item>indent</Item>
-                        <Item>indentBlock</Item>
                         <Item>outdent</Item>
                         <Item>alignment</Item>
                     </Array>
@@ -803,7 +802,6 @@
                 <Item>
                     <Array>
                         <Item>indent</Item>
-                        <Item>indentBlock</Item>
                         <Item>outdent</Item>
                         <Item>alignment</Item>
                     </Array>


### PR DESCRIPTION
The item `indentBlock` does not need to be listed explicitly in the toolbar configuration: "If the plugin Indent is defined, it [the plugin IndentBlock] also attaches the 'indentBlock' and 'outdentBlock' commands to the 'indent' and 'outdent' commands".

Source: https://ckeditor.com/docs/ckeditor5/latest/api/module_indent_indentblock-IndentBlock.html

references #5415