### PR TITLE
Issue #5262: Removed maxlength from HTML.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceTransportHTTPREST.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceTransportHTTPREST.tt
@@ -167,7 +167,7 @@
 [% IF Data.CommunicationType == 'Requester' %]
                             <label class="Mandatory" for="Host"><span class="Marker">*</span>[% Translate("Endpoint") | html %]:</label>
                             <div class="Field">
-                                <input id="Host" class="W50pc [% Data.HostServerError | html %] Validate_Required" type="text" maxlength="250" value="[% Data.Host | html %]" name="Host"/>
+                                <input id="Host" class="W50pc [% Data.HostServerError | html %] Validate_Required" type="text" value="[% Data.Host | html %]" name="Host"/>
                                 <div id="HostError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
                                 <div id="HostServerError" class="TooltipErrorMessage"><p>[% Translate(Data.HostServerErrorMessage) | html %]</p></div>
                                 <p class="FieldExplanation">


### PR DESCRIPTION
closes #5262

Removed maxlength from HTML, since Module `AdminGenericInterfaceTransportHTTPREST.pm:419` does not actually check for this. Requester config is instead directly passed to `Kernel/System/GenericInterface/Webservice.pm:320`, where it is dumped to YAML and persisted to DB.