### PR TITLE
Marked Znuny4OTOBOAdvancedDynamicFields::DynamicFieldValid values as translatable

### DIFF
--- a/Kernel/Config/Files/XML/DynamicFields.xml
+++ b/Kernel/Config/Files/XML/DynamicFields.xml
@@ -1906,8 +1906,8 @@
             <Navigation>Core</Navigation>
             <Value>
                 <Item ValueType="Select" SelectedID="1">
-                    <Item ValueType="Option" Value="1">valid</Item>
-                    <Item ValueType="Option" Value="0">invalid</Item>
+                    <Item ValueType="Option" Value="1" Translatable="1">valid</Item>
+                    <Item ValueType="Option" Value="0" Translatable="1">invalid</Item>
                 </Item>
             </Value>
         </Setting>


### PR DESCRIPTION
This PR is for `rel-11_0` and contains the same changes as in https://github.com/RotherOSS/otobo/pull/5515