### PR TITLE
Issue #2545: require Perl 5.26

### DIFF
--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -39,6 +39,7 @@ use File::stat     qw(stat);
 use Try::Tiny;
 
 # OTOBO modules
+use Kernel::MinimalPerlVersion    ();
 use Kernel::System::ModuleRefresh (); # based on Module::Refresh
 
 our @EXPORT = qw(Translatable); ## no critic qw(Modules::ProhibitAutomaticExportation)

--- a/Kernel/MinimalPerlVersion.pm
+++ b/Kernel/MinimalPerlVersion.pm
@@ -1,0 +1,39 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+package Kernel::MinimalPerlVersion;
+
+use v5.26;    # requiring Perl 5.26 is the intent of this module
+use warnings;
+
+# core modules
+
+# CPAN modules
+
+# OTOBO modules
+
+our $ObjectManagerDisabled = 1;
+
+=head1 NAME
+
+Kernel::MinimalPerlVersion - declare the minimal version of Perl for OTOBO
+
+=head1 DESCRIPTION
+
+This module only requires a minimal version of Perl for OTOBO.
+
+=cut
+
+1;

--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -103,6 +103,7 @@ use Term::ReadLine;    # avoids error when checking for Term::ReadLine::Gnu
 # CPAN modules
 
 # OTOBO modules
+use Kernel::MinimalPerlVersion    ();
 use Kernel::System::Environment   ();
 use Kernel::System::VariableCheck qw(IsHashRefWithData IsArrayRefWithData);
 

--- a/bin/otobo.Console.pl
+++ b/bin/otobo.Console.pl
@@ -29,6 +29,7 @@ use lib dirname($RealBin) . '/Custom';
 # CPAN modules
 
 # OTOBO modules
+use Kernel::MinimalPerlVersion    ();
 use Kernel::System::ObjectManager ();
 
 my $RetCode;

--- a/bin/otobo.Daemon.pl
+++ b/bin/otobo.Daemon.pl
@@ -39,6 +39,7 @@ use File::Copy  qw(move);
 # CPAN modules
 
 # OTOBO modules
+use Kernel::MinimalPerlVersion    ();
 use Kernel::System::ObjectManager ();
 
 # Disable warnings for redefined subroutines by setting our own WARN signal handler.

--- a/bin/psgi-bin/otobo.psgi
+++ b/bin/psgi-bin/otobo.psgi
@@ -87,6 +87,7 @@ use Plack::App::File      ();
 use Plack::App::Directory ();
 
 # OTOBO modules
+use Kernel::MinimalPerlVersion ();
 use Kernel::Config;                                             # assure that Kernel/Config.pm exists, though the file might be modified later
 use Kernel::System::ModuleRefresh                 ();           # based on Module::Refresh
 use Kernel::System::ObjectManager                 ();


### PR DESCRIPTION
the minimal version of Perl is declared in Kernel/MinimalPerlVersion.pm.

See https://metacpan.org/release/XSAWYERX/perl-5.26.0/view/pod/perldelta.pod for new features in Perl 5.26. Welcome to indented heredocs.