### PR TITLE
Update cpanminus build command

### DIFF
--- a/scripts/tools/build-rhel-modules.sh
+++ b/scripts/tools/build-rhel-modules.sh
@@ -53,7 +53,7 @@ cp cpanfile.plackup cpanfile -f
 
 if [ -f "cpanfile" ]; then
     echo "Installing dependencies to $TARGET_LIB..."
-    cpanm --local-lib "$TARGET_LIB" --self-contained --notest --mirror "http://www.cpan.org" --mirror-only --installdeps .
+    cpanm --local-lib "$TARGET_LIB" --self-contained --notest --mirror "https://cpan.metacpan.org" --installdeps .
 else
     echo "Error: Couldn't find cpanfile in $PROJECT_ROOT!"
     exit 1


### PR DESCRIPTION
Refering to #5521.

> Currently the `scripts/tools/build-rhel-modules.sh` script has a relatively poor performance when executed by an CI-Runner.
> 
> After testing this is mainly caused by the following reasons:
> - The script only relies on one mirror
> - The `cpan.org` mirror is used which provides slower download speeds compared `cpan.metacpan.org`
> - The `cpan.org` mirror doesn't archive some older pinned versions of perl modules

The following changes have been tested on an internal gitlab ci runner intance.