### PR TITLE
Issue #5532: require the Docker versions for cpanfile.plackup

### DIFF
--- a/bin/otobo.CheckModules.pl
+++ b/bin/otobo.CheckModules.pl
@@ -360,7 +360,8 @@ my $ExitCode = 0;    # success
 # That attributes accepts a version range like they are known from cpanfiles.
 #
 # There are cases when a different or more strict version is desired in a Docker build. This version can be
-# specified with the attribute 'DockerVersionRequired'.
+# specified with the attribute 'DockerVersionRequired'. This attribute is also used for the versions for
+# cpanfile.plackup.
 #
 # ATTENTION: when making changes here then make sure that you also regenerate the cpanfiles:
 #            bin/otobo.CheckModules.pl --generate-cpanfiles
@@ -1924,9 +1925,12 @@ sub PrintCpanfile {
             }
 
             # there may be additional restrictions on the versions
-            # exact version for Docker builds has higher priority
+            # exact version for Docker builds has higher priority for cpanfile.docker and cpanfile.plackup.
             my $VersionRequirement = '';
             if ( $ForDocker && $Module->{DockerVersionRequired} ) {
+                $VersionRequirement = qq{, '$Module->{DockerVersionRequired}'};
+            }
+            elsif ( $ForPlackup && $Module->{DockerVersionRequired} ) {
                 $VersionRequirement = qq{, '$Module->{DockerVersionRequired}'};
             }
             elsif ( $Module->{VersionRequired} ) {

--- a/cpanfile.plackup
+++ b/cpanfile.plackup
@@ -172,40 +172,40 @@ requires 'Plack::Middleware::ReverseProxy';
 
 # feature 'div:cldr', 'Support for feature div:cldr' => sub {
     # localisation from the CLDR project
-    requires 'Locale::CLDR', '== 0.44.1';
+    requires 'Locale::CLDR', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ar', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Ar', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::De', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::De', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Es', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Es', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Fr', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Fr', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Hu', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Hu', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ko', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Ko', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Nb', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Nb', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Pt', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Pt', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Ru', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Ru', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Sr', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Sr', '== 0.46.0';
 
     # language packs from the CLDR project
-    requires 'Locale::CLDR::Locales::Zh', '== 0.44.1';
+    requires 'Locale::CLDR::Locales::Zh', '== 0.46.0';
 
 # };
 


### PR DESCRIPTION
This is currently only relevant for Locale::CLDR where we want to use 0.46.0. This version is compatible with carton.