### PR TITLE
Issue #5512: use the unquoted phrase

### DIFF
--- a/Kernel/System/Queue.pm
+++ b/Kernel/System/Queue.pm
@@ -111,11 +111,34 @@ sub new {
 
 =head2 GetSystemAddress()
 
-get a queue system email address as hash (Email, RealName)
+get a queue system email address as hash.
 
     my %Address = $QueueObject->GetSystemAddress(
         QueueID => 123,
     );
+
+The attributes of the returned hash are
+
+=over 4
+
+=item Email: the address part of the system address
+
+=item RealName: the quoted phrase of the system address
+
+=item Phrase: the unquoted phrase of the system address
+
+=back
+
+When the address is 'gustl@testanything.org' and the phrase is 'August, Ausprobierer' we get:
+
+    my %Address = (
+        Email    => q{gustl@testanything.org},
+        RealName => q{"August, Ausprobierer"},
+        Phrase   => q{August, Ausprobierer},
+    );
+
+This means that "$Address{RealName} <$Address{Email}>" is a valid email. And the unquoted C<Phrase>
+can be used in C<Kernel::System::EmailAddress::Format()>.
 
 =cut
 
@@ -136,11 +159,14 @@ sub GetSystemAddress {
     );
 
     while ( my @Row = $DBObject->FetchrowArray() ) {
-        $Address{Email}    = $Row[0];
-        $Address{RealName} = $Row[1];
+        $Address{Email} = $Row[0];
+
+        # Return the unquoted phrase for use with Kernel::System::EmailAddress.
+        $Address{Phrase} = $Row[1];
     }
 
-    # prepare realname quote
+    # prepare realname quote, for constructing emails like "$Address{RealName} <$Address{Email}>".
+    $Address{RealName} = $Address{Phrase};
     if ( $Address{RealName} =~ /(,|@|\(|\)|:)/ && $Address{RealName} !~ /^("|')/ ) {
         $Address{RealName} =~ s/"/\"/g;
         $Address{RealName} = '"' . $Address{RealName} . '"';

--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -315,13 +315,16 @@ sub Sender {
         }
     }
 
+    # get needed objects
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # get sender attributes
     my %Address = $Kernel::OM->Get('Kernel::System::Queue')->GetSystemAddress(
         QueueID => $Param{QueueID},
     );
 
-    # get config object
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    # This is the not quoted RealName
+    my $Phrase = $Address{Phrase};
 
     # check config for agent real name
     my $UseAgentRealName = $ConfigObject->Get('Ticket::DefineEmailFrom');
@@ -339,8 +342,8 @@ sub Sender {
             # check for user data
             if ( $UserData{UserFullname} ) {
 
-                # rewrite RealName
-                $Address{RealName} = "$UserData{UserFullname}";
+                # rewrite the phrase, no need to care about quoting
+                $Phrase = $UserData{UserFullname};
             }
         }
 
@@ -350,15 +353,9 @@ sub Sender {
             # check for user data
             if ( $UserData{UserFullname} ) {
 
-                # rewrite RealName
-                my $Separator = ' ' . $ConfigObject->Get('Ticket::DefineEmailFromSeparator');
-
-                # $Address{RealName} comes from GetSystemAddress() which might already have added double quotes.
-                # Let's strip those before constructing a new RealName aka phrase.
-                $Address{RealName} =~ s/^"(.*)"$/$1/;
-
-                # prepend the user name to the real name
-                $Address{RealName} = $UserData{UserFullname} . $Separator . ' ' . $Address{RealName};
+                # prepend the user name and the separator, e.g. 'via', to the real name
+                my $Separator = $ConfigObject->Get('Ticket::DefineEmailFromSeparator');
+                $Phrase = "$UserData{UserFullname} $Separator $Phrase";
             }
         }
     }
@@ -368,7 +365,7 @@ sub Sender {
     my $EmailAddressObject = $Kernel::OM->Get('Kernel::System::EmailAddress');
 
     return $EmailAddressObject->Format(
-        Realname => $Address{RealName},
+        Realname => $Phrase,
         Address  => $Address{Email},
     );
 }


### PR DESCRIPTION
in Kernel::System::TemplateGenerator::Sender(). Using the quoted phrase could result in an extra pair of quote characters.

For that Kernels::System::Queue::GetSystemAddress() has been enhanced to also return the unquoted phrase.