### PR TITLE
Issue #5430: Removed 'Active' check from agent preferences.

### DIFF
--- a/Kernel/Modules/AgentPreferences.pm
+++ b/Kernel/Modules/AgentPreferences.pm
@@ -465,7 +465,7 @@ sub Run {
             # OverriddenFileName is used only in Admin interface.
             delete $Setting->{OverriddenFileName};
 
-            # If the setting is overriden in the *.pm file, take it as default and update IsModified.
+            # If the setting is overridden in the *.pm file, take it as default and update IsModified.
             my $GlobalEffectiveValue = $SysConfigObject->GlobalEffectiveValueGet(
                 SettingName => $Setting->{Name},
             );
@@ -539,7 +539,7 @@ sub Run {
     }
 
     # ------------------------------------------------------------ #
-    # Return user favourite system configuration settings.
+    # Return user favorite system configuration settings.
     # ------------------------------------------------------------ #
     elsif ( $Self->{Subaction} eq 'UserSystemConfigurationFavourites' ) {
 
@@ -677,7 +677,7 @@ sub AgentPreferencesForm {
             # OverriddenFileName is used only in Admin interface.
             delete $Setting->{OverriddenFileName};
 
-            # If the setting is overriden in the *.pm file, take it as default and update IsModified.
+            # If the setting is overridden in the *.pm file, take it as default and update IsModified.
             my $GlobalEffectiveValue = $SysConfigObject->GlobalEffectiveValueGet(
                 SettingName => $Setting->{Name},
             );
@@ -972,7 +972,7 @@ sub _SettingReset {
                 TargetUserID => $Self->{CurrentUserID},
             );
 
-            # If the setting is overriden in the *.pm file, take it as default and update IsModified.
+            # If the setting is overridden in the *.pm file, take it as default and update IsModified.
             my $GlobalEffectiveValue = $SysConfigObject->GlobalEffectiveValueGet(
                 SettingName => $SettingName,
             );

--- a/Kernel/Modules/AgentPreferences.pm
+++ b/Kernel/Modules/AgentPreferences.pm
@@ -133,15 +133,12 @@ sub Run {
         # check preferences setting
         my %Preferences = %{ $ConfigObject->Get('PreferencesGroups') };
 
-        GROUP:
         for my $Group (@Groups) {
             if ( !$Preferences{$Group} ) {
                 return $LayoutObject->ErrorScreen(
                     Message => $LayoutObject->{LanguageObject}->Translate( 'No such config for %s', $Group ),
                 );
             }
-
-            next GROUP unless ( $Self->{CurrentUserID} != $EditUserID || $Preferences{$Group}{Active} );
 
             # get user data
             my %UserData = $UserObject->GetUserData( UserID => $Self->{CurrentUserID} );


### PR DESCRIPTION
The check was based on a misunderstanding of the meaning of the 'Active'
attribute.

closes #5430

Partially reverting #4323.