### PR TITLE
Make rhel archive name more generic

### DIFF
--- a/scripts/tools/build-rhel-modules.sh
+++ b/scripts/tools/build-rhel-modules.sh
@@ -20,7 +20,7 @@ set -Euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 PROJECT_ROOT="$SCRIPT_DIR/../.."
 TARGET_LIB="$PROJECT_ROOT/install/local"
-ARCHIVE_NAME="otobo-deps-11.0-rhel-9.7.tar.gz"
+ARCHIVE_NAME="otobo-deps-rhel.tar.gz"
 # Directory at /opt/otobo to compress to tar.gz
 ARCHIVE_DIR="install"
 


### PR DESCRIPTION
Referring to #5639.

The tar archive name created by the `scripts/tools/build-rhel-modules.sh` script has been changed from `otobo-deps-11.0-rhel-9.7.tar.gz` to `otobo-deps-rhel.tar.gz` to make it more generic for further OTOBO versions and RHEL releases.

Because the script relies on the cpanfile.plackup from the cloned repository locally, it's functionality is independent of the current OTOBO version because it always uses the local plackup file which already gets updated on new OTOBO versions if necessary.

The correct archive names for release packages on https://ftp.otobo.org are getting handeled by a dedicated CI-Runner.