### PR TITLE
Issue #5641: Explicitly do not translate entites and perl modules.

### DIFF
--- a/Kernel/System/SysConfig/ValueType/Entity.pm
+++ b/Kernel/System/SysConfig/ValueType/Entity.pm
@@ -15,6 +15,7 @@
 # --
 
 package Kernel::System::SysConfig::ValueType::Entity;
+
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::LayoutObject)
 
 use strict;
@@ -337,6 +338,7 @@ sub SettingRender {
         Disabled      => $Param{RW} ? 0 : 1,
         SelectedValue => $EffectiveValue,
         Title         => $Param{Name},
+        Translation   => 0,
         OptionTitle   => 1,
         Class         => "$Param{Class} Modernize",
     );
@@ -415,6 +417,7 @@ sub AddItem {
         ID            => $Param{Name} . $Param{IDSuffix},
         SelectedValue => $Param{DefaultItem}->{Content},
         Title         => $Param{Name},
+        Translation   => 0,
         OptionTitle   => 1,
         Class         => "$Param{Class} Modernize Entry",
     );

--- a/Kernel/System/SysConfig/ValueType/PerlModule.pm
+++ b/Kernel/System/SysConfig/ValueType/PerlModule.pm
@@ -15,6 +15,7 @@
 # --
 
 package Kernel::System::SysConfig::ValueType::PerlModule;
+
 ## nofilter(TidyAll::Plugin::OTOBO::Perl::LayoutObject)
 
 use strict;
@@ -309,6 +310,7 @@ sub SettingRender {
         Disabled      => $Param{RW} ? 0 : 1,
         SelectedValue => $EffectiveValue,
         Title         => $Param{Name},
+        Translation   => 0,
         OptionTitle   => 1,
         Class         => "$Param{Class} Modernize",
     );
@@ -400,6 +402,7 @@ sub AddItem {
         ID            => $Param{Name} . $Param{IDSuffix},
         SelectedValue => $Param{DefaultItem}->{Content},
         Title         => $Param{Name},
+        Translation   => 0,
         OptionTitle   => 1,
         Class         => "$Param{Class} Modernize Entry",
     );


### PR DESCRIPTION
this affects respective value type entity dropdowns in system configuration. The Translation has to be set to 0 explicitly because it defaults to 1 if not set.

closes #5641