### PR TITLE
Issue #5494: Doubled the name length for ACLs in HTML.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminACLEdit.tt
@@ -87,7 +87,7 @@
                     <fieldset class="TableLike">
                         <label class="Mandatory" for="Name"><span class="Marker">*</span> [% Translate("Name") | html %]:</label>
                         <div class="Field">
-                            <input type="text" name="Name" id="Name" value="[% Data.Name | html %]" class="W50pc Validate_Required [% Data.NameServerError | html %]" maxlength="70"/>
+                            <input type="text" name="Name" id="Name" value="[% Data.Name | html %]" class="W50pc Validate_Required [% Data.NameServerError | html %]" maxlength="140"/>
                             <div id="NameError" class="TooltipErrorMessage">
                                 <p>[% Translate("This field is required.") | html %]</p>
                             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminACLNew.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminACLNew.tt
@@ -69,7 +69,7 @@
                     <fieldset class="TableLike">
                         <label class="Mandatory" for="Name"><span class="Marker">*</span> [% Translate("Name") | html %]:</label>
                         <div class="Field">
-                            <input type="text" name="Name" id="Name" value="[% Data.Name | html %]" class="W50pc Validate_Required [% Data.NameServerError | html %]" maxlength="70"/>
+                            <input type="text" name="Name" id="Name" value="[% Data.Name | html %]" class="W50pc Validate_Required [% Data.NameServerError | html %]" maxlength="140"/>
                             <div id="NameError" class="TooltipErrorMessage">
                                 <p>[% Translate("This field is required.") | html %]</p>
                             </div>


### PR DESCRIPTION
It remains unclear why the HTML maxlength was 70 while the respective DB column allowed 191.

closes #5494