### PR TITLE
Issue #5686: Removed default values for some settings.

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -9991,7 +9991,6 @@ via the Preferences button after logging in.
         <Value>
             <Array>
                 <DefaultItem ValueType="Entity" ValueEntityType="Queue" ValueRegex=""></DefaultItem>
-                <Item ValueType="Entity" ValueEntityType="Queue" ValueRegex="">Junk</Item>
             </Array>
         </Value>
     </Setting>

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -7064,7 +7064,6 @@
         <Value>
             <Array>
                 <DefaultItem ValueType="Entity" ValueEntityType="Queue" ValueRegex=""></DefaultItem>
-                <Item ValueType="Entity" ValueEntityType="Queue" ValueRegex="">Raw</Item>
             </Array>
         </Value>
     </Setting>


### PR DESCRIPTION
Deployment may fail if queues are invalid, renamed or deleted and thus the setting values can't be validated.

references #5686