### PR TITLE
Issue #5427: add the option --no-report-skipped to the translation de…

### DIFF
--- a/Kernel/System/Console/Command/Maint/Translations/Deploy.pm
+++ b/Kernel/System/Console/Command/Maint/Translations/Deploy.pm
@@ -41,6 +41,13 @@ sub Configure {
         'Deploy the translations. This needs to be execute as part of the upgrade procedure'
     );
 
+    $Self->AddOption(
+        Name        => 'no-report-skipped',
+        Description => 'be less verbose',
+        Required    => 0,
+        HasValue    => 0,
+    );
+
     return;
 }
 
@@ -50,8 +57,9 @@ sub Run {
     my $ConfigObject       = $Kernel::OM->Create('Kernel::Config');
     my $TranslationsObject = $Kernel::OM->Create('Kernel::System::Translations');
 
-    my %LanguageID2Name = $Kernel::OM->Get('Kernel::Config')->Get('DefaultUsedLanguages')->%*;
+    my %LanguageID2Name = $ConfigObject->Get('DefaultUsedLanguages')->%*;
     my $NumLanguages    = scalar keys %LanguageID2Name;
+    my $BeQuiet         = $Self->GetOption('no-report-skipped');
 
     $Self->Print("Handling $NumLanguages languages\n");
 
@@ -71,7 +79,9 @@ sub Run {
             $TranslationItems->@*;
 
         if ( !%ActiveTranslations ) {
-            $Self->PrintWarning("Skipping $Name $LanguageID as there are no active translations\n");
+            if ( !$BeQuiet ) {
+                $Self->PrintWarning("Skipping $Name $LanguageID as there are no active translations\n");
+            }
             $NumSkipped++;
 
             next LANGUAGE_ID;

--- a/bin/docker/entrypoint.sh
+++ b/bin/docker/entrypoint.sh
@@ -182,7 +182,7 @@ function do_update_tasks() {
         ($OTOBO_HOME/bin/otobo.Console.pl Maint::Config::Rebuild 2>&1)
         ($OTOBO_HOME/bin/otobo.Console.pl Maint::Cache::Delete 2>&1)
         ($OTOBO_HOME/bin/otobo.Console.pl Maint::Loader::CacheCleanup 2>&1)
-        ($OTOBO_HOME/bin/otobo.Console.pl Maint::Translations::Deploy 2>&1)
+        ($OTOBO_HOME/bin/otobo.Console.pl Maint::Translations::Deploy --no-report-skipped 2>&1)
         date
         echo "finished $FUNCNAME()"
         echo


### PR DESCRIPTION
…ploy

for less verbose output.
Added the option '--no-report-skipped' when calling Maint::Translations::Deploy in entrypoint.sh