### PR TITLE
Issue #5717: early exit when Elasticsearch is not active

### DIFF
--- a/scripts/DBUpdateTo11_1/EnableSimilarSearchWidgetIfESActivated.pm
+++ b/scripts/DBUpdateTo11_1/EnableSimilarSearchWidgetIfESActivated.pm
@@ -24,7 +24,6 @@ use utf8;
 use parent qw(scripts::DBUpdateTo11_1::Base);
 
 # core modules
-use List::Util qw(any);
 
 # CPAN modules
 
@@ -46,12 +45,23 @@ scripts::DBUpdateTo11_1::EnableSimilarSearchWidgetIfESActivated - Activate the S
 sub Run {
     my ( $Self, %Param ) = @_;
 
-    my $Result          = 0;
-    my $ConfigObject    = $Kernel::OM->Get('Kernel::Config');
-    my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $LogObject    = $Kernel::OM->Get('Kernel::System::Log');
 
+    # nothing to do when Elasticsearch is not active
     my $ElasticsearchActivated = $ConfigObject->Get('Elasticsearch::Active');
-    if ($ElasticsearchActivated) {
+    if ( !$ElasticsearchActivated ) {
+        $LogObject->Log(
+            Priority => 'info',
+            Message  => 'The similar search widget is not enabled as Elasticsearch is not active.',
+        );
+
+        return 1;
+    }
+
+    # Elastissearch is active, do some work
+    {
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
         my %Setting = $SysConfigObject->SettingGet(
             Name => 'Ticket::Frontend::AgentTicketZoom###Widgets###0400-SimilarTickets',
@@ -64,7 +74,7 @@ sub Run {
         );
 
         # enable similar search widget
-        my %Result = $SysConfigObject->SettingUpdate(
+        my %SettingUpdateResult = $SysConfigObject->SettingUpdate(
             Name              => 'Ticket::Frontend::AgentTicketZoom###Widgets###0400-SimilarTickets',
             IsValid           => 1,
             UserID            => 1,
@@ -72,42 +82,39 @@ sub Run {
             EffectiveValue    => $Setting{EffectiveValue},
         );
 
-        if ( !$Result{Success} ) {
-            $Kernel::OM->Get('Kernel::System::Log')->Log(
+        if ( !$SettingUpdateResult{Success} ) {
+            $$LogObject->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => 'Could not activate the Similar Ticket Search Widget for the TicketZoom mask.',
             );
 
-            return $Result;
-        }
-        else {
-            $Result = 1;
+            return 0;
         }
 
         my $Success = $SysConfigObject->SettingUnlock(
             UserID    => 1,
             DefaultID => $Setting{DefaultID},
         );
-    }
 
-    my %DeploymentResult = $SysConfigObject->ConfigurationDeploy(
-        Comments      => "UpgradeTo11.1 - Activate the Similar Search Widget if ES is activated.",
-        UserID        => 1,
-        Force         => 1,
-        DirtySettings => ['Ticket::Frontend::AgentTicketZoom###Widgets###0400-SimilarTickets'],
-    );
-
-    if ( !$DeploymentResult{Success} ) {
-
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => "Deployment failed.",
+        my %DeploymentResult = $SysConfigObject->ConfigurationDeploy(
+            Comments      => "UpgradeTo11.1 - Activate the Similar Search Widget if ES is activated.",
+            UserID        => 1,
+            Force         => 1,
+            DirtySettings => ['Ticket::Frontend::AgentTicketZoom###Widgets###0400-SimilarTickets'],
         );
 
-        $Result = 0;
+        if ( !$DeploymentResult{Success} ) {
+            $LogObject->Log(
+                Priority => 'error',
+                Message  => "Deployment failed.",
+            );
+
+            return 0;
+        }
     }
 
-    return $Result;
+    # looks good
+    return 1;
 }
 
 1;


### PR DESCRIPTION
return successfully as an inactive Elasticsearch is a regular case

The relevant change is the a deployment is only done when the SysConfig was actually changed.