### PR TITLE
Issue #5772: adapt Cache.t\n for rel-11_1 when no redis available

### DIFF
--- a/scripts/test/Cache.t
+++ b/scripts/test/Cache.t
@@ -104,7 +104,7 @@ for my $ModuleFile (@BackendModuleFiles) {
         # Under Docker Redis should be available.
         # In a classical Installation we don't know. So we tentatively try to connect
         # to the configured Redis Server, and proceed only if that works.
-        if ( $Module =~ m/Redis/i && !$ENV{OTOBO_RUNS_UNDER_DOCKER} ) {
+        if ( $Module =~ m/Redis/i ) {
             next MODULEFILE unless $CacheObject->{CacheObject}->_Connect();
         }
 


### PR DESCRIPTION
closes #5772 