### PR TITLE
Issue #5785: Exit successfully if setting couldn't be retrieved.

### DIFF
--- a/scripts/DBUpdateTo11_1/SysConfigMigrateArticleActions.pm
+++ b/scripts/DBUpdateTo11_1/SysConfigMigrateArticleActions.pm
@@ -60,11 +60,11 @@ sub Run {
         # This case also occurs on installations that were installed as 11.1.x. But in that case
         # there is no obvious reason why the migration is executed.
         $LogObject->Log(
-            Priority => 'error',
+            Priority => 'notice',
             Message  => "Could not retrieve the setting Ticket::Frontend::Article::Actions",
         );
 
-        return;
+        return 1;
     }
 
     # hardcoded content of 11.0 default config for comparison later on

--- a/scripts/DBUpdateTo11_1/SysConfigMigrateDynamicFieldNamespaces.pm
+++ b/scripts/DBUpdateTo11_1/SysConfigMigrateDynamicFieldNamespaces.pm
@@ -32,6 +32,7 @@ use List::Util qw(any);
 use Kernel::System::VariableCheck qw(IsArrayRefWithData);
 
 our @ObjectDependencies = (
+    'Kernel::Config',
     'Kernel::System::Log',
     'Kernel::System::SysConfig',
 );
@@ -45,6 +46,9 @@ scripts::DBUpdateTo11_1::SysConfigMigrateDynamicFieldNamespaces - Copy dynamic f
 sub Run {
     my ( $Self, %Param ) = @_;
 
+    # prevent error message due to invalid setting
+    return 1 unless $Kernel::OM->Get('Kernel::Config')->Get('DynamicField::Namespaces');
+
     my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
 
     # fetch old setting for checks and retrieving old value
@@ -53,11 +57,11 @@ sub Run {
     );
     if ( !%OldDynamicFieldNamespacesSetting ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
+            Priority => 'notice',
             Message  => "Could not fetch setting 'DynamicField::Namespaces' - aborting."
         );
 
-        return;
+        return 1;
     }
 
     # report success if value is empty


### PR DESCRIPTION
This may happen on a fresh system or during repeated execution of the
upgrade script.

closes #5785