### PR TITLE
Issue #5801: skip pwd masking if pwd is empty

### DIFF
--- a/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
+++ b/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
@@ -193,7 +193,9 @@ sub Run {
             # Hide password contained in error message and print message back to standard error.
             # Please see bug#12829 for more information.
             if ($ErrorMessage) {
-                $ErrorMessage =~ s/\Q$Data{Password}\E/********/g;
+                if( $Data{Password} ) {
+                    $ErrorMessage =~ s/\Q$Data{Password}\E/********/g;
+                }
                 print STDERR $ErrorMessage;
             }
 


### PR DESCRIPTION
In case of XOAUTH2/OAUTHBEARER pwd will be empty, which will make the regex match everything.

closes #5801 