### PR TITLE
Issue #3861: Correct handling of readonly styling in customer interface

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -434,6 +434,7 @@ Core.UI.InputFields = (function (TargetNS) {
 
         $SearchObj.prop('readonly', false);
         $InputContainerObj.removeClass('AlreadyDisabled');
+        $SearchObj.closest('.Field').removeClass('oooReadonly');
 
         // Check if there are only empty and disabled options
         if ($SelectObj.find('option')
@@ -448,6 +449,7 @@ Core.UI.InputFields = (function (TargetNS) {
             $SearchObj
                 .attr('readonly', true)
                 .attr('title', Core.Language.Translate('Not available'));
+            $SearchObj.closest('.Field').addClass('oooReadonly');
 
             // when the original field does no longer provide any valid options,
             // we also want to remove existing selections
@@ -461,6 +463,7 @@ Core.UI.InputFields = (function (TargetNS) {
                 .removeAttr('title')
                 .prop('readonly', false)
                 .val('');
+            $SearchObj.closest('.Field').removeClass('oooReadonly');
         }
     }
 

--- a/var/httpd/htdocs/js/Core.UI.InputFields.js
+++ b/var/httpd/htdocs/js/Core.UI.InputFields.js
@@ -434,7 +434,9 @@ Core.UI.InputFields = (function (TargetNS) {
 
         $SearchObj.prop('readonly', false);
         $InputContainerObj.removeClass('AlreadyDisabled');
-        $SearchObj.closest('.Field').removeClass('oooReadonly');
+        if ( Config.CustomerInterface === true ) {
+            $SearchObj.closest('.Field').removeClass('oooReadonly');
+        }
 
         // Check if there are only empty and disabled options
         if ($SelectObj.find('option')
@@ -449,7 +451,9 @@ Core.UI.InputFields = (function (TargetNS) {
             $SearchObj
                 .attr('readonly', true)
                 .attr('title', Core.Language.Translate('Not available'));
-            $SearchObj.closest('.Field').addClass('oooReadonly');
+            if ( Config.CustomerInterface === true ) {
+                $SearchObj.closest('.Field').addClass('oooReadonly');
+            }
 
             // when the original field does no longer provide any valid options,
             // we also want to remove existing selections
@@ -463,7 +467,9 @@ Core.UI.InputFields = (function (TargetNS) {
                 .removeAttr('title')
                 .prop('readonly', false)
                 .val('');
-            $SearchObj.closest('.Field').removeClass('oooReadonly');
+            if ( Config.CustomerInterface === true ) {
+                $SearchObj.closest('.Field').removeClass('oooReadonly');
+            }
         }
     }
 


### PR DESCRIPTION
On e.g. CustomerTicketMessage the SLA dropdown will change it's readonly state dynamically after page load, necessitating setting and removing the .oooReadOnly class accordingly.