### PR TITLE
Issue #5505: Also remove title from unit test.

### DIFF
--- a/scripts/test/Selenium/Agent/FormDraft/AgentTicketActionCommonDraft.t
+++ b/scripts/test/Selenium/Agent/FormDraft/AgentTicketActionCommonDraft.t
@@ -240,12 +240,6 @@ $Selenium->RunTest(
             {
                 Module => 'Responsible',
                 Fields => {
-                    Title => {
-                        ID     => 'Title',
-                        Type   => 'Input',
-                        Value  => 'Selenium Responsible Title',
-                        Update => 'Selenium Responsible Title - Update'
-                    },
                     Subject => {
                         ID     => 'Subject',
                         Type   => 'Input',


### PR DESCRIPTION
AgentTicketResponsible does not have a title field anymore by default. Easiest is to adapt the test.

references #5505