### PR TITLE
tidying activity dialogs

### DIFF
--- a/Kernel/Modules/AdminOIDCProfiles.pm
+++ b/Kernel/Modules/AdminOIDCProfiles.pm
@@ -165,7 +165,7 @@ sub Run {
         $GetParam{RandLength}        = $ParamObject->GetParam( Param => 'RandLength' ) || 22;
         $GetParam{RandTTL}           = $ParamObject->GetParam( Param => 'RandTTL' )    || 60 * 5;
         $GetParam{Leeway}            = $ParamObject->GetParam( Param => 'Leeway' )     || 2;
-        $GetParam{ValidID}           = $ParamObject->GetParam( Param => 'ValidID' )    // 1;
+        $GetParam{ValidID}           = $ParamObject->GetParam( Param => 'ValidID' ) // 1;
 
         # prevent duplicate account names
         if ( $Self->{Subaction} eq 'AddProfileAction' ) {

--- a/Kernel/Modules/AdminProcessManagementActivityDialog.pm
+++ b/Kernel/Modules/AdminProcessManagementActivityDialog.pm
@@ -536,7 +536,7 @@ sub Run {
                     $Error{GlobalServerError}        = 'ServerError';
                     $Error{GlobalServerErrorMessage} = Translatable(
                         'ActivityDialogs currently used in gobal '
-                        . 'Activities may not be set to non-global!'
+                            . 'Activities may not be set to non-global!'
                     );
                 }
                 else {
@@ -546,7 +546,7 @@ sub Run {
                         $Error{GlobalServerError}        = 'ServerError';
                         $Error{GlobalServerErrorMessage} = Translatable(
                             'ActivityDialogs currently used in non-gobal Activities '
-                            . 'of other Processes may not be set to non-global!'
+                                . 'of other Processes may not be set to non-global!'
                         );
                     }
                 }

--- a/Kernel/System/Auth/OpenIDConnect.pm
+++ b/Kernel/System/Auth/OpenIDConnect.pm
@@ -373,7 +373,7 @@ sub PreAuth {
     );
 
     my %Data = (
-        State => $RandomString . ($Param{RequestedURL} // '' ),
+        State => $RandomString . ( $Param{RequestedURL} // '' ),
     );
 
     # store the RandomString as a CSRF cookie

--- a/Kernel/System/Console/Command/Dev/Code/CPANAudit.pm
+++ b/Kernel/System/Console/Command/Dev/Code/CPANAudit.pm
@@ -26,7 +26,7 @@ use parent qw(Kernel::System::Console::BaseCommand);
 
 # core modules
 use Config;    # import %Config
-use Cwd qw(abs_path);
+use Cwd        qw(abs_path);
 use List::Util qw(none);
 
 # CPAN modules

--- a/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
+++ b/Kernel/System/Console/Command/Maint/PostMaster/MailAccountFetch.pm
@@ -196,7 +196,7 @@ sub Run {
             # Hide password contained in error message and print message back to standard error.
             # Please see bug#12829 for more information.
             if ($ErrorMessage) {
-                if( $Data{Password} ) {
+                if ( $Data{Password} ) {
                     $ErrorMessage =~ s/\Q$Data{Password}\E/********/g;
                 }
                 print STDERR $ErrorMessage;

--- a/Kernel/System/Elasticsearch.pm
+++ b/Kernel/System/Elasticsearch.pm
@@ -501,12 +501,12 @@ sub TicketSearch {
             }
         }
 
-# Issue 5814- reduce logging, re-enable for debugging manually if needed:
-#
-#        $Kernel::OM->Get('Kernel::System::Log')->Log(
-#            Priority => 'debug',
-#            Message  => "Elasticsearch [ticket] Similar Search Query: " . $Param{MoreLikeThis}
-#        );
+        # Issue 5814- reduce logging, re-enable for debugging manually if needed:
+        #
+        #$Kernel::OM->Get('Kernel::System::Log')->Log(
+        #    Priority => 'debug',
+        #    Message  => "Elasticsearch [ticket] Similar Search Query: " . $Param{MoreLikeThis}
+        #);
 
         # add queue restrictions
         push @Musts, {
@@ -566,11 +566,12 @@ sub TicketSearch {
     my $Total   = $Result->{Data}->{Total}   // 0;
     my $Records = $Result->{Data}->{Records} // [];
 
-# Issue 5814- reduce logging, re-enable for debugging manually if needed:
-#    $Kernel::OM->Get('Kernel::System::Log')->Log(
-#        Priority => 'debug',
-#        Message  => "Elasticsearch [ticket] Result: " . $Total . " Hits\n"
-#    );
+    # Issue 5814- reduce logging, re-enable for debugging manually if needed:
+    #
+    #$Kernel::OM->Get('Kernel::System::Log')->Log(
+    #    Priority => 'debug',
+    #    Message  => "Elasticsearch [ticket] Result: " . $Total . " Hits\n"
+    #);
 
     # convert the Elasticsearch return to the needed OTRS structure and return
 

--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -530,13 +530,13 @@ Core.UI.RichTextEditor = (function (TargetNS) {
                 });
 
                 // resize editor when resizable container changes size for any reason (e.g. window resize, sidebar toggle)
-                // currently this leads to the editor growing endlessly if activated for the customer interface or 
+                // currently this leads to the editor growing endlessly if activated for the customer interface or
                 // RichTextEditors in TableLike forms (e.g. Admin Interface)
                 let InModularForm = $domEditableElement.closest("fieldset").hasClass("ModularForm");
                 if (!CustomerInterface && InModularForm) {
                     resizeObserver.observe($domEditableElement.get(0));
                 }
-                
+
                 //make sure editor size is adjusted as well whenever the toolbar changes size
                 resizeObserver.observe(editor.ui.view.toolbar.element);
 


### PR DESCRIPTION
Follow conventions for messages. Fix the misspelling 'gobal'.