### PR TITLE
Issue #5880: Overflow auto caused the scrollbar.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Widget.css
@@ -149,18 +149,6 @@ ul.Tablelike li.Header + li {
 
 .WidgetSimple > .Content {
     padding: 8px 8px 10px;
-    overflow: auto;
-    /**
-     *   START IE9 Hover Bug Workaround
-     *   The problem occurs when you have a container that has a fixed width set, an overflow set to
-     *   auto, content long enough to trigger the horizontal scroll and a hover style set
-     *   on elements inside the container.
-     *   The container mysteriously increases in size.
-     *   (e.g. if you have installed OTOBODashboardOverviewFilters and many dynamic fields are
-     *   shown in the dashboard.)
-     */
-    min-height: 0%;
-    /* END IE9 Hover Bug Workaround */
 }
 
 .WidgetSimple > .Content.OverflowVisible {


### PR DESCRIPTION
While at it, remove Internet Explorer 9 workaround as Internet Explorer is no longer supported.

closes #5880