### PR TITLE
Allow packages to register custom CKEditor 5 plugins (#5896)

### DIFF
--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -137,11 +137,16 @@ Core.UI.RichTextEditor = (function (TargetNS) {
         }
 
         var ClassicEditor = CKEditor5Wrapper.ClassicEditor;
+        // Custom plugins (e.g. from OTOBO packages) can be registered in the
+        // window.CKEditor5CustomPlugins registry. The CKEditor5Wrapper module
+        // namespace itself is not extensible, so bundled plugins are looked up
+        // there and custom ones in the registry.
+        let CustomPlugins = window.CKEditor5CustomPlugins || {};
         let EnabledPlugins = [];
         for (let pluginName of PluginList) {
-            let Plugin = CKEditor5Wrapper[pluginName];
+            let Plugin = CKEditor5Wrapper[pluginName] || CustomPlugins[pluginName];
             if (Plugin) {
-                EnabledPlugins.push(CKEditor5Wrapper[pluginName]);
+                EnabledPlugins.push(Plugin);
             } else {
                 Core.Exception.ShowError('Couldn\'t find plugin: ' + pluginName, 'JavaScriptError');
             }


### PR DESCRIPTION
Resolves #5896

### Summary
`Frontend::CKEditorPlugins` makes the plugin list configurable, but plugin names are resolved against the `CKEditor5Wrapper` ES module namespace only. Module namespace objects are not extensible, so OTOBO packages cannot provide their own CKEditor 5 plugins — adding a custom name to the SysConfig setting can only produce `Couldn't find plugin`.

This change resolves plugin names against a `window.CKEditor5CustomPlugins` registry as fallback:

```js
let CustomPlugins = window.CKEditor5CustomPlugins || {};
let Plugin = CKEditor5Wrapper[pluginName] || CustomPlugins[pluginName];
```

A package can then ship a loader JS file that registers its plugin class (written against the exposed `window.CKEditor5Wrapper` namespace) and activate it by adding its name to `Frontend::CKEditorPlugins`.

### Behavior
- No change for standard installations: bundled plugins resolve exactly as before, the registry is only consulted for names the bundle does not export.
- Restores the extension point that existed in `rel-11_0` (`window.CKEditor5Plugins` in `Core.UI.CKEditor5Wrapper.js`).

### Motivation / real-world use case
We are shipping CKEditor 4 era behavior customers rely on as small CKEditor 5 plugins (an Office clipboard normalizer restoring Excel cell colors — see #5898 — and an image border toggle). Both are proven to work; this fallback is the only missing piece to run them on 11.1 without core patches.
