### PR TITLE
Issue #5913: Added empty fallback in case of missing sysconfig setting.

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldScreen.pm
+++ b/Kernel/Modules/AdminDynamicFieldScreen.pm
@@ -89,7 +89,7 @@ sub new {
                         @ObjectTypesFilter = qw(Ticket Article);
                     }
                     else {
-                        @ObjectTypesFilter = $DFScreensObjectTypesConfig->{$ConfigKey}->@*;
+                        @ObjectTypesFilter = @{ $DFScreensObjectTypesConfig->{$ConfigKey} // [] };
                     }
                     last CONFIGKEY;
                 }
@@ -105,7 +105,7 @@ sub new {
                         @ObjectTypesFilter = qw(Ticket Article);
                     }
                     else {
-                        @ObjectTypesFilter = $DFScreensObjectTypesConfig->{$ConfigKey}->@*;
+                        @ObjectTypesFilter = @{ $DFScreensObjectTypesConfig->{$ConfigKey} // [] };
                     }
                     last CONFIGKEY;
                 }


### PR DESCRIPTION
Needed in case that a package does not declare the object types applicable to their dynamic field screen entries.

closes #5913