### PR TITLE
Issue #5922: Restricted filterable dynamic fields.

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldDB.pm
+++ b/Kernel/Modules/AdminDynamicFieldDB.pm
@@ -842,9 +842,10 @@ sub _ShowScreen {
     # Get a list of available dynamic fields for use as filters.
     my %DynamicFieldList = %{
         $DynamicFieldObject->DynamicFieldList(
+            ObjectType => [ 'Ticket', 'Article' ],
             Valid      => 1,
             ResultType => 'HASH',
-        )
+        ) // {}
     };
 
     # Add the dynamic fields to the hash.


### PR DESCRIPTION
Only fields of object types ticket and article are currently actually usable as filter for dynamic fields of field type database.

closes #5922