### PR TITLE
Fixed concatenation issues for translatable strings

### DIFF
--- a/Kernel/Modules/AdminProcessManagementActivityDialog.pm
+++ b/Kernel/Modules/AdminProcessManagementActivityDialog.pm
@@ -535,8 +535,7 @@ sub Run {
 
                     $Error{GlobalServerError}        = 'ServerError';
                     $Error{GlobalServerErrorMessage} = Translatable(
-                        'ActivityDialogs currently used in gobal '
-                            . 'Activities may not be set to non-global!'
+                        'Activity dialogs currently used in global activities may not be set to non-global.'
                     );
                 }
                 else {
@@ -545,8 +544,7 @@ sub Run {
 
                         $Error{GlobalServerError}        = 'ServerError';
                         $Error{GlobalServerErrorMessage} = Translatable(
-                            'ActivityDialogs currently used in non-gobal Activities '
-                                . 'of other Processes may not be set to non-global!'
+                            'Activity dialogs currently used in non-global activities of other processes may not be set to non-global.'
                         );
                     }
                 }


### PR DESCRIPTION
`Translatable()` no-op function does not work with concatenated strings. The `otobo.pot` contains only the first part of the string.

```
#. Perl Module: Kernel/Modules/AdminProcessManagementActivityDialog.pm
msgid "ActivityDialogs currently used in gobal "
msgstr ""

#. Perl Module: Kernel/Modules/AdminProcessManagementActivityDialog.pm
msgid "ActivityDialogs currently used in non-gobal Activities "
msgstr ""
```

This PR fixes the issue.