### PR TITLE
Moved link inside the string to avoid concatenated string to translate

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -207,9 +207,7 @@
                         <div class="Field MailAccount">
                             [% Data.AccountOptionAdd %]
                             <p class="FieldExplanation">
-                            [% Translate("Select the") | html %]
-                            <a target="_blank" href="?Action=AdminOAuthTokenStore">OIDC</a>
-                            [% Translate("Account to use for OAuth2 authentication.") | html %]
+                            [% Translate("Select the %sOIDC%s account to use for OAuth2 authentication.") | html | ReplacePlaceholders('<a target="_blank" href="?Action=AdminOAuthTokenStore">', '</a>') %]</p>
                             </p>
 
                             <div id="AccountAddError" class="TooltipErrorMessage">

--- a/Kernel/Output/HTML/Templates/Standard/AdminOIDCProfiles.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminOIDCProfiles.tt
@@ -50,8 +50,7 @@
                 <br>
                 <p>
                 [% IF Data.AllItemsCount != 0 %]
-                    [% Translate("You can connect OIDC profiles with a OIDC functional account") | html %]
-                    <a href="?Action=AdminOAuthTokenStore">[% Translate("here") | html %]</a>.
+                    [% Translate("You can connect OIDC profiles with a OIDC functional account %shere%s.") | html | ReplacePlaceholders('<a href="?Action=AdminOAuthTokenStore">', '</a>') %]
                 [% END %]
                 </p>
                 <br>


### PR DESCRIPTION
If the string is concatenated or contains an untranslatable part, translators cannot change the word order if the target language requires it. This PR adds the `<a href="...">...</a>` HTML element as placeholder to the string, so translators can change the word order freely and translate the string as a whole sentence.