### PR TITLE
Issue #5924: Removed title and richtext from filterable dynamic fields.

### DIFF
--- a/Kernel/Modules/AdminDynamicFieldDB.pm
+++ b/Kernel/Modules/AdminDynamicFieldDB.pm
@@ -877,10 +877,8 @@ sub _ShowScreen {
                 'Service',
                 'Ticket',
                 'ScriptTemplateToolkit',
-                'RichText',
                 'TextArea',
                 'Text',
-                'Title',
             ],
             Valid => 1,
         ) // []


### PR DESCRIPTION
Both have been decided to not be useful as filter for dynamic field database.

references #5924