### PR TITLE
Issue #5956 native entrypoint refractoring

### DIFF
--- a/scripts/systemd/otobo-daemon.service
+++ b/scripts/systemd/otobo-daemon.service
@@ -8,7 +8,7 @@ User = otobo
 Group = otobo
 WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
-Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5:/opt/otobo/local/lib/perl5
+Environment = PERL5LIB=/opt/otobo/local/lib/perl5:/opt/otobo/install/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart = /opt/otobo/bin/otobo.Daemon.pl start
 ExecStop = /opt/otobo/bin/otobo.Daemon.pl stop

--- a/scripts/systemd/otobo-daemon.service
+++ b/scripts/systemd/otobo-daemon.service
@@ -8,7 +8,7 @@ User = otobo
 Group = otobo
 WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
-Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
+Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5:/opt/otobo/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart = /opt/otobo/bin/otobo.Daemon.pl start
 ExecStop = /opt/otobo/bin/otobo.Daemon.pl stop

--- a/scripts/systemd/otobo-web.service
+++ b/scripts/systemd/otobo-web.service
@@ -11,7 +11,7 @@ WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
 Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart = exec plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
+ExecStart = plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
 Restart = always
 
 [Install]

--- a/scripts/systemd/otobo-web.service
+++ b/scripts/systemd/otobo-web.service
@@ -9,7 +9,7 @@ User = otobo
 Group = otobo
 WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
-Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
+Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5:/opt/otobo/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart = plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
 Restart = always

--- a/scripts/systemd/otobo-web.service
+++ b/scripts/systemd/otobo-web.service
@@ -11,7 +11,7 @@ WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
 Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart = /opt/otobo/bin/docker/entrypoint.sh web
+ExecStart = exec plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
 Restart = always
 
 [Install]

--- a/scripts/systemd/otobo-web.service
+++ b/scripts/systemd/otobo-web.service
@@ -9,7 +9,7 @@ User = otobo
 Group = otobo
 WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
-Environment = PERL5LIB=/opt/otobo/install/local/lib/perl5:/opt/otobo/local/lib/perl5
+Environment = PERL5LIB=/opt/otobo/local/lib/perl5:/opt/otobo/install/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart = plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
 Restart = always


### PR DESCRIPTION
Referring to #5956.

The ExecStart for the `otobo-web.service` has been moved from the docker `entrypoint.sh` to the original plackup file.

The new command has been tested on a native Ubuntu 20.04 LTS installation of OTOBO 11.1.

<img width="2378" height="1227" alt="Bildschirmfoto 2026-08-04 um 13 18 02" src="https://github.com/user-attachments/assets/2c898a58-2a37-4cbf-93a0-f58ac0ce4ccd" />

The port will stay at 5000 internally because the usage of a reverse proxy should still be recommended for all setups due to higher flexibility. Therefore no installation manual needs to be updated and future version upgrades require no additional migration steps.