### PR TITLE
Issue #4507: Migrate to latest release version for spnego nginx plugin

### DIFF
--- a/otobo.nginx.dockerfile
+++ b/otobo.nginx.dockerfile
@@ -14,7 +14,7 @@
 # https://gist.github.com/hermanbanken/96f0ff298c162a522ddbba44cad31081
 FROM nginx:mainline-trixie AS builder-for-kerberos
 
-ARG SPNEGO_VERSION=1.1.1
+ARG SPNEGO_VERSION=1.1.3
 
 RUN apt-get update\
  && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install\


### PR DESCRIPTION
Referring to #4507.

Since switching from `spnego-nginx` to `libpam-krb5` is no option this PR contains several changes to ensure the latest stable version of spnego-http-auth-nginx-module.

This feature has been tested on a local otobo-nginx-kerberos-webproxy container. The module has been loaded successfully.
<img width="1098" height="563" alt="Bildschirmfoto 2026-08-05 um 14 02 40" src="https://github.com/user-attachments/assets/e8c8c013-e9a0-4aab-80e0-38fa2ffcf6da" />
