### PR TITLE
Fixed concatenation issues in field explanations

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericAgentImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericAgentImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of generic agents to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminGroupImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGroupImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of groups to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -207,7 +207,7 @@
                         <div class="Field MailAccount">
                             [% Data.AccountOptionAdd %]
                             <p class="FieldExplanation">
-                            [% Translate("Select the %sOIDC%s account to use for OAuth2 authentication.") | html | ReplacePlaceholders('<a target="_blank" href="?Action=AdminOAuthTokenStore">', '</a>') %]</p>
+                            [% Translate("Select the %sOIDC%s account to use for OAuth2 authentication.") | html | ReplacePlaceholders('<a target="_blank" href="?Action=AdminOAuthTokenStore">', '</a>') %]
                             </p>
 
                             <div id="AccountAddError" class="TooltipErrorMessage">
@@ -351,9 +351,7 @@
                         <div class="Field MailAccount">
                             [% Data.AccountOption %]
                             <p class="FieldExplanation">
-                            [% Translate("Select the") | html %]
-                            <a target="_blank" href="?Action=AdminOAuthTokenStore">OIDC</a>
-                            [% Translate("Account to use for OAuth2 authentication.") | html %]
+                            [% Translate("Select the %sOIDC%s account to use for OAuth2 authentication.") | html | ReplacePlaceholders('<a target="_blank" href="?Action=AdminOAuthTokenStore">', '</a>') %]
                             </p>
                             <div id="AccountAddError" class="TooltipErrorMessage">
                                 <p>[% Translate("This field is required.") | html %]</p>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueueImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueueImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of queues to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplatesImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueueTemplatesImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of queue-template relations to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleGroupImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleGroupImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of role-group relations to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminRoleImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminRoleImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of roles to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSLAImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSLAImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of SLAs to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminServiceImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminServiceImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of services to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminTemplateImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTemplateImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of templates to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminTypeImportExport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminTypeImportExport.tt
@@ -55,19 +55,20 @@
             <div class="Content">
                 <div class="FieldExplanation">
                     <p>
-                        <b>
-                            [% Translate("Select the items you want to ") | html %] [% Translate(Data.Type) | html %].
-                        </b>
-
-                        <p>
-                            </br>
 [% RenderBlockStart("ImportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to import.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Select the desired elements and confirm the import with 'import'.") | html %]
 [% RenderBlockEnd("ImportHint") %]
 [% RenderBlockStart("ExportHint") %]
+                        <b>
+                            [% Translate("Select the items you want to export.") | html %]
+                        </b>
+                        </br>
                         [% Translate("Here you can export a configuration file of types to import these on another system. The configuration file is exported in yml format.") | html %]
 [% RenderBlockEnd("ExportHint") %]
-                         </p>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This is a follow-up fix for #5936 as the same structure was used in multiple files.

This PR fixes the concatenation issues in the same way in all related screens.