### PR TITLE
Issue #5956: Bind gazelle webserver port on localhost

### DIFF
--- a/scripts/systemd/otobo-web.service
+++ b/scripts/systemd/otobo-web.service
@@ -11,7 +11,7 @@ WorkingDirectory = /opt/otobo
 Environment = OTOBO_HOME=/opt/otobo
 Environment = PERL5LIB=/opt/otobo/local/lib/perl5:/opt/otobo/install/local/lib/perl5
 Environment = PATH=/opt/otobo/local/bin:/opt/otobo/install/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart = plackup --server Gazelle --env deployment --port 5000 bin/psgi-bin/otobo.psgi
+ExecStart = plackup --server Gazelle --env deployment --port 5000 --host localhost bin/psgi-bin/otobo.psgi
 Restart = always
 
 [Install]


### PR DESCRIPTION
Referring to #5956.

This binds Gazelle webserver Port 5000 from `otobo-web.service` to localhost.
By default, it ensures that the port will never be exposed to other hosts - even when the hosts firewall is absent or misconfigured.

Otobo webservices should only be exposed using a reverse proxy. The user can change this behavior by creating a systemd override file for `otobo-web`. 

This change has been tested on a native Otobo 11.1 installation.