### PR TITLE
Issue #3746: remove unused variable %Callbacks

### DIFF
--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -272,44 +272,6 @@ sub Connect {
 
     # db connect
     {
-
-        # Attribute for callbacks. See https://metacpan.org/pod/DBI#Callbacks
-        my %Callbacks;
-        {
-            if ( $Self->{Backend}->{'DB::Connect'} ) {
-
-                # run a command for initializing a session
-                my $DBConnectSQL = $Self->{Backend}->{'DB::Connect'};
-
-                # maybe deactivate foreign key checks
-                my $DeactivateSQL;
-                if ( $Self->{DeactivateForeignKeyChecks} ) {
-                    $DeactivateSQL = $Self->GetDatabaseFunction('DeactivateForeignKeyChecks');
-                }
-
-                $Callbacks{connected} = sub {
-                    my $DatabaseHandle = shift;
-
-                    if ($DBConnectSQL) {
-                        $DatabaseHandle->do($DBConnectSQL);
-                    }
-
-                    if ($DeactivateSQL) {
-                        $DatabaseHandle->do($DeactivateSQL);
-                    }
-
-                    return;
-                };
-            }
-
-            # In OTOBO 10.0.x running with PostgreSQL the flag pg_enable_utf8 was set to 1.
-            # According to https://metacpan.org/pod/DBD::Pg#pg_enable_utf8-(integer)
-            # this is no longer necessary.
-            #if ( $Self->{Backend}->{'DB::Type'} eq 'postgresql' ) {
-            #    $ConnectAttributes{pg_enable_utf8} = 1;
-            #}
-        }
-
         # Note that the default values for the attributes RaiseError and AutoInactiveDestroy differ
         # between DBI and DBIx::Connector. For DBI they are off per default, but for DBIx::Connector
         # they are on per default.


### PR DESCRIPTION
That variable was likely added in rel-11_1 when merging changes from rel-11_0. Note that in Connect() there is a second variable that is also called  %Callbacks. This variable is actually used.