### PR TITLE
Issue #6094: Allow bypassing EditFieldValueGet for reference value.

### DIFF
--- a/Kernel/System/DynamicField/Driver/Lens.pm
+++ b/Kernel/System/DynamicField/Driver/Lens.pm
@@ -101,7 +101,7 @@ sub ValueGet {
     my $LensDFConfig = $Param{DynamicFieldConfig};
 
     # in set case, an arrayref of object ids is returned
-    my $ReferencedObjectID = $Self->_GetReferencedObjectID(
+    my $ReferencedObjectID = $Param{ReferencedObjectID} || $Self->_GetReferencedObjectID(
         ObjectID               => $Param{ObjectID},
         LensDynamicFieldConfig => $LensDFConfig,
         EditFieldValue         => $Param{UseReferenceEditField},
@@ -723,8 +723,9 @@ sub GetFieldState {
                 # TODO: Instead we could just send $DFParam->{ $DynamicFieldConfig->{Config}{ReferenceDFName} } as ObjectID
                 # but we would need to interpret it later (from ConfigItemID to LastVersionID, e.g.)
                 # TODO: Validate the Reference ObjectID here, or earlier, to prevent data leaks!
-                ObjectID              => 1,    # will not be used;
+                ObjectID              => 1,                                                                                     # will not be used;
                 UseReferenceEditField => 1,
+                ReferencedObjectID    => $Param{GetParam}{DynamicField}{ $DynamicFieldConfig->{Config}{ReferenceDFName} }[0],
             ) // '';
         }
         else {


### PR DESCRIPTION
Usually, a lens field fetches its reference field value via EditFieldValueGet. On initial rendering, this needs to be bypassed to allow subsequent calculation depending on the lens field value.

closes #6094