### PR TITLE
Fix Elasticsearch missing-document recovery for typeless errors

### DIFF
--- a/Kernel/GenericInterface/Invoker/Elasticsearch/TicketManagement.pm
+++ b/Kernel/GenericInterface/Invoker/Elasticsearch/TicketManagement.pm
@@ -881,11 +881,20 @@ sub HandleResponse {
     #     "type":"document_missing_exception",\
     #     "reason":"[_doc][5]: document missing","index_uuid":"rH43T-SsTz-H_k8aFg13dQ","shard":"0","index":"ticket"},"status":404}
     if ( $Param{Data}->{error} && $Param{Data}->{error}->{type} eq 'document_missing_exception' ) {
+        # Elasticsearch can report either "[_doc][5]: document missing" or "[5]: document missing".
+        my $Reason = $Param{Data}->{error}->{reason} // '';
+        my ($TicketID) = $Reason =~ m/ \A (?: \Q[_doc]\E )? \[ ([0-9]+) \]: \s document \s missing \z /x;
+        if ( !$TicketID ) {
+            return {
+                Success      => 0,
+                ErrorMessage => 'Could not determine TicketID from Elasticsearch document_missing_exception.',
+            };
+        }
+
         my $ESObject      = $Kernel::OM->Get('Kernel::System::Elasticsearch');
         my $ArticleObject = $Kernel::OM->Get('Kernel::System::Ticket::Article');
 
         # create the ticket
-        my ($TicketID) = $Param{Data}->{error}->{reason} =~ m/ \Q[_doc][\E ([0-9]+) \Q]:\E \s /x;    # e.g. "[_doc][5]: "
         my $Errors = 0;
         if ( !$ESObject->TicketCreate( TicketID => $TicketID ) ) {
             $Errors++;

--- a/scripts/test/GenericInterface/Invoker/Elasticsearch/TicketManagement.t
+++ b/scripts/test/GenericInterface/Invoker/Elasticsearch/TicketManagement.t
@@ -1,0 +1,99 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+
+use v5.24;
+use strict;
+use warnings;
+
+use Test2::V0;
+use Kernel::GenericInterface::Invoker::Elasticsearch::TicketManagement;
+
+# Only record recovery calls: no database, Elasticsearch or ticket changes.
+{
+    package TicketManagementTest::Objects;
+
+    sub Get {
+        return $_[0];
+    }
+
+    sub TicketCreate {
+        my ( $Self, %Param ) = @_;
+        push $Self->{Calls}->@*, [ TicketCreate => \%Param ];
+        return 1;
+    }
+
+    sub ArticleList {
+        my ( $Self, %Param ) = @_;
+        push $Self->{Calls}->@*, [ ArticleList => \%Param ];
+        return ( { ArticleID => 11 }, { ArticleID => 12 } );
+    }
+
+    sub ArticleCreate {
+        my ( $Self, %Param ) = @_;
+        push $Self->{Calls}->@*, [ ArticleCreate => \%Param ];
+        return 1;
+    }
+}
+
+my $Invoker = bless {}, 'Kernel::GenericInterface::Invoker::Elasticsearch::TicketManagement';
+
+for my $Reason ( '[_doc][5]: document missing', '[5]: document missing' ) {
+    subtest $Reason => sub {
+        local $Kernel::OM = bless { Calls => [] }, 'TicketManagementTest::Objects';
+        my $Result = $Invoker->HandleResponse(
+            ResponseSuccess => 1,
+            Data            => { error => { type => 'document_missing_exception', reason => $Reason } },
+        );
+        ok( $Result->{Success}, 'recovery succeeds' );
+        is(
+            $Kernel::OM->{Calls},
+            [
+                [ TicketCreate  => { TicketID => 5 } ],
+                [ ArticleList   => { TicketID => 5 } ],
+                [ ArticleCreate => { TicketID => 5, ArticleID => 11 } ],
+                [ ArticleCreate => { TicketID => 5, ArticleID => 12 } ],
+            ],
+            'recreates the ticket and all its articles with the recovered ID',
+        );
+    };
+}
+
+for my $Reason ( undef, '', '[abc]: document missing', '[0]: document missing',
+    '[5]: unexpected error', 'prefix [5]: document missing', '[5]: document missing suffix' )
+{
+    subtest 'invalid reason: ' . ( $Reason // 'undef' ) => sub {
+        local $Kernel::OM = bless { Calls => [] }, 'TicketManagementTest::Objects';
+        my $Result = $Invoker->HandleResponse(
+            ResponseSuccess => 1,
+            Data            => { error => { type => 'document_missing_exception', reason => $Reason } },
+        );
+        ok( !$Result->{Success}, 'reports an error when no valid ID can be recovered' );
+        like( $Result->{ErrorMessage}, qr/Could not determine TicketID/, 'explains recovery failure' );
+        is( $Kernel::OM->{Calls}, [], 'does not call ticket or article APIs with an invalid ID' );
+    };
+}
+
+{
+    local $Kernel::OM = bless { Calls => [] }, 'TicketManagementTest::Objects';
+    my $Result = $Invoker->HandleResponse( ResponseSuccess => 1, Data => { result => 'updated' } );
+    ok( $Result->{Success}, 'normal response remains successful' );
+    is( $Kernel::OM->{Calls}, [], 'normal response does not trigger recovery' );
+    $Result = $Invoker->HandleResponse( ResponseSuccess => 0, ResponseErrorMessage => 'transport failed' );
+    is( $Result, { Success => 0, ErrorMessage => 'transport failed' }, 'transport errors are preserved' );
+}
+
+done_testing;


### PR DESCRIPTION
Updating a ticket whose Elasticsearch document is missing should recreate the ticket and its articles. With Elasticsearch 9.4.4, the existing recovery path passes an undefined TicketID because it only recognizes the older `[_doc][5]: document missing` reason, while Elasticsearch now returns `[5]: document missing`.

Accept both reason formats and stop recovery with a clear error when a valid TicketID cannot be extracted, before calling ticket or article APIs. The existing recovery sequence is otherwise unchanged. Add an isolated regression test covering both formats, malformed/missing IDs, ticket and article recovery calls, and ordinary/transport responses.

Validation:
- The regression test fails on the original module for the newer response format and passes with this patch (12 top-level TAP tests, including subtests; no database or Elasticsearch access).
- Tested on OTOBO 11.1.0-beta2 with Elasticsearch 9.4.4 using the same module as current `rel-11_1`. Before the patch, a synchronous TicketManagement update for an actually missing document returned Success=1, logged three `Need TicketID!` errors, and left the document missing.
- After patching the module, the same update triggered the existing self-repair path successfully. All 18 affected tickets were recovered through OTOBO, with all 37 article entries verified against database counts. Repeating an update on one recovered ticket did not duplicate its articles. No direct document insertion or full index rebuild was used.
- The full application test suite was not run on the live installation.

Related to the self-repair behavior introduced for #1471. We discovered these index gaps while investigating an installation affected by the separate crash issue #5972. The missing tickets dated from the earlier failure period, but this does not establish that the driver crash directly corrupted Elasticsearch: the defect fixed here is the failure to recover a missing document, regardless of how it became missing.
