### PR TITLE
Issue #6099: Align label translation for Set fields.

### DIFF
--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1918,13 +1918,16 @@ sub MaskAgentZoom {
                                         # no ValueMaxChars here, enough space available
                                     );
 
+                                    # use translation here to be able to reduce the character length in the template
+                                    my $Label = $LayoutObject->{LanguageObject}->Translate( $IncludeDFConfig->{Label} );
+
                                     my %IncludeField = (
                                         $IncludeDFConfig->{Name} => $ValueStrg->{Title},
                                         Name                     => $IncludeDFConfig->{Name},
                                         Title                    => $ValueStrg->{Title},
                                         Value                    => $ValueStrg->{Value},
                                         ValueKey                 => $ValueItem->{ $IncludeDFConfig->{Name} },
-                                        Label                    => $IncludeDFConfig->{Label},
+                                        Label                    => $Label,
                                         Link                     => $ValueStrg->{Link},
                                         LinkPreview              => $ValueStrg->{LinkPreview},
 
@@ -2107,13 +2110,16 @@ sub MaskAgentZoom {
                             # no ValueMaxChars here, enough space available
                         );
 
+                        # use translation here to be able to reduce the character length in the template
+                        my $Label = $LayoutObject->{LanguageObject}->Translate( $IncludeDFConfig->{Label} );
+
                         my %IncludeField = (
                             $IncludeDFConfig->{Name} => $ValueStrg->{Title},
                             Name                     => $IncludeDFConfig->{Name},
                             Title                    => $ValueStrg->{Title},
                             Value                    => $ValueStrg->{Value},
                             ValueKey                 => $ValueItem->{ $IncludeDFConfig->{Name} },
-                            Label                    => $IncludeDFConfig->{Label},
+                            Label                    => $Label,
                             Link                     => $ValueStrg->{Link},
                             LinkPreview              => $ValueStrg->{LinkPreview},
 


### PR DESCRIPTION
For normal fields in the widget, translation has always been done perl-side. This has been overlooked when adding the Set field handling.

Fixes d2906406fdb6004e3083bbf2072e324c59b9e32f.

closes #6099