### PR TITLE
Protect attachment integrity during storage migration

### DIFF
--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -7608,7 +7608,7 @@ sub TicketArticleStorageSwitch {
 
         # read source attachments
         my @Attachments;
-        my %MD5Sums;
+        my %AttachmentSignatures;
 
         MD5SUMFILE:
         for my $FileID ( sort keys %InitialSourceAttachmentIndex ) {
@@ -7653,7 +7653,16 @@ sub TicketArticleStorageSwitch {
             my $MD5Sum = $MainObject->MD5sum(
                 String => $Attachment{Content},
             );
-            $MD5Sums{$MD5Sum}++;
+            my $Signature = join "\x1e", map { $_ // '' }
+                $MD5Sum,
+                $InitialSourceAttachmentIndex{$FileID}->{VersionID},
+                $InitialSourceAttachmentIndex{$FileID}->{Filename},
+                $InitialSourceAttachmentIndex{$FileID}->{ContentType},
+                $InitialSourceAttachmentIndex{$FileID}->{ContentID},
+                $InitialSourceAttachmentIndex{$FileID}->{ContentAlternative},
+                $InitialSourceAttachmentIndex{$FileID}->{Disposition},
+                $InitialSourceAttachmentIndex{$FileID}->{FilesizeRaw};
+            $AttachmentSignatures{$Signature}++;
         }
 
         # nothing to transfer
@@ -7879,10 +7888,19 @@ sub TicketArticleStorageSwitch {
             my $MD5Sum = $MainObject->MD5sum(
                 String => \$Attachment{Content},
             );
-            if ( $MD5Sums{$MD5Sum} ) {
-                $MD5Sums{$MD5Sum}--;
-                if ( !$MD5Sums{$MD5Sum} ) {
-                    delete $MD5Sums{$MD5Sum};
+            my $Signature = join "\x1e", map { $_ // '' }
+                $MD5Sum,
+                $DestinationAttachmentIndex{$FileID}->{VersionID},
+                $DestinationAttachmentIndex{$FileID}->{Filename},
+                $DestinationAttachmentIndex{$FileID}->{ContentType},
+                $DestinationAttachmentIndex{$FileID}->{ContentID},
+                $DestinationAttachmentIndex{$FileID}->{ContentAlternative},
+                $DestinationAttachmentIndex{$FileID}->{Disposition},
+                $DestinationAttachmentIndex{$FileID}->{FilesizeRaw};
+            if ( $AttachmentSignatures{$Signature} ) {
+                $AttachmentSignatures{$Signature}--;
+                if ( !$AttachmentSignatures{$Signature} ) {
+                    delete $AttachmentSignatures{$Signature};
                 }
             }
             else {
@@ -7918,7 +7936,7 @@ sub TicketArticleStorageSwitch {
         }
 
         # check if all files are moved
-        if (%MD5Sums) {
+        if (%AttachmentSignatures) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  =>

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase/ArticleStorageDB.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase/ArticleStorageDB.pm
@@ -278,7 +278,8 @@ sub ArticleWriteAttachment {
     my $UniqueFilename = $OrigFilename;
     {
         my %Index = $Self->ArticleAttachmentIndex(
-            ArticleID => $Param{ArticleID},
+            ArticleID     => $Param{ArticleID},
+            OnlyMyBackend => 1,
         );
 
         my %UsedFile = map

--- a/scripts/test/Ticket/ArticleStorageSwitch.t
+++ b/scripts/test/Ticket/ArticleStorageSwitch.t
@@ -49,6 +49,10 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
         Key   => 'Ticket::Article::Backend::MIMEBase::ArticleStorage',
         Value => 'Kernel::System::Ticket::Article::Backend::MIMEBase::' . $SourceBackend,
     );
+    $ConfigObject->Set(
+        Key   => 'Ticket::Article::Backend::MIMEBase::CheckAllStorageBackends',
+        Value => 1,
+    );
 
     my $TicketObject         = $Kernel::OM->Get('Kernel::System::Ticket');
     my $ArticleObject        = $Kernel::OM->Get('Kernel::System::Ticket::Article');
@@ -147,6 +151,8 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
             # check file attributes
             for my $AttachmentID ( sort keys %{ $ArticleIDs{$ArticleID} } ) {
 
+                my $Found;
+
                 ATTACHMENTINDEXID:
                 for my $ID ( sort keys %Index ) {
                     if (
@@ -156,6 +162,7 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
                     {
                         next ATTACHMENTINDEXID;
                     }
+                    $Found = 1;
                     for my $Attribute ( sort keys %{ $ArticleIDs{$ArticleID}->{$AttachmentID} } ) {
                         $Self->Is(
                             $Index{$ID}->{$Attribute},
@@ -164,6 +171,10 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
                         );
                     }
                 }
+                $Self->True(
+                    $Found,
+                    "$NamePrefix - Verify before - attachment found (ArticleID:$ArticleID)"
+                );
             }
         }
 
@@ -190,6 +201,8 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
             # check file attributes
             for my $AttachmentID ( sort keys %{ $ArticleIDs{$ArticleID} } ) {
 
+                my $Found;
+
                 ATTACHMENTINDEXID:
                 for my $ID ( sort keys %Index ) {
                     if (
@@ -199,6 +212,7 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
                     {
                         next ATTACHMENTINDEXID;
                     }
+                    $Found = 1;
                     for my $Attribute ( sort keys %{ $ArticleIDs{$ArticleID}->{$AttachmentID} } ) {
                         $Self->Is(
                             $Index{$ID}->{$Attribute},
@@ -207,6 +221,10 @@ for my $SourceBackend (qw(ArticleStorageDB ArticleStorageFS)) {
                         );
                     }
                 }
+                $Self->True(
+                    $Found,
+                    "$NamePrefix - Verify after - attachment found (ArticleID:$ArticleID)"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Prevent attachment filenames and metadata from changing silently when MIME articles are migrated between filesystem and database storage.

## How to reproduce

1. Store an article with attachments in `ArticleStorageFS`.
2. Enable `Ticket::Article::Backend::MIMEBase::CheckAllStorageBackends`.
3. Ensure the corresponding destination in `ArticleStorageDB` is empty.
4. Run `TicketArticleStorageSwitch` from `ArticleStorageFS` to `ArticleStorageDB`.
5. Compare the attachment filenames before and after migration.

## Current behavior

While writing the attachment to the database, the filename-collision check searches all configured storage backends. It therefore sees the source attachment in the filesystem and incorrectly treats its filename as already occupied in the database.

For example, `attachment.pdf` can be stored in the database as
`attachment-1.pdf`.

The subsequent migration verification compares only content checksums. Because
the file content is unchanged, verification succeeds and the correctly named
source attachment is deleted.

The existing regression test can also overlook the renamed attachment because
it performs no assertion when the expected filename is absent.

## Expected behavior

- Filename-collision detection should consider only attachments already present
  in the destination backend.
- The source attachment should be deleted only after both its content and
  relevant metadata have been preserved.

## Related issue

Follow-up to #1757 and #4527.

PR #4527 fixed attachment renaming for DB-to-FS migrations by restricting
the filesystem backend's filename-collision lookup to that backend. The
equivalent lookup in `ArticleStorageDB` remains unscoped, so an FS-to-DB
migration with `CheckAllStorageBackends` enabled can still treat the source
attachment as a destination collision and rename it.

This PR completes the symmetric fix for the database backend and additionally
prevents content-only verification from accepting filename or metadata changes.

## Changes

- Restrict database filename-collision checks to `ArticleStorageDB`.
- Compare source and destination attachments using signatures containing:
  - content checksum
  - version ID
  - filename
  - content type
  - content ID
  - content-alternative marker
  - disposition
  - raw file size
- Preserve attachment multiplicity when identical signatures occur more than
  once.
- Remove destination attachments and retain the source if an attachment is
  missing or its content or metadata differs.
- Enable `CheckAllStorageBackends` in the storage-switch regression test.
- Explicitly assert that every expected attachment filename is present before
  and after migration.

## Testing

- `git diff --check`
- `perl -I. -c Kernel/System/Ticket.pm`
- `perl -I. -c Kernel/System/Ticket/Article/Backend/MIMEBase/ArticleStorageDB.pm`

Not run locally:

- `scripts/test/Ticket/ArticleStorageSwitch.t` — requires a database-backed
  OTOBO test environment