### PR TITLE
Fix REST Basic authentication header formatting for Elasticsearch

### DIFF
--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -679,8 +679,9 @@ sub RequesterPerformRequest {
                 && IsStringWithData( $Config->{Proxy}->{ProxyPassword} )
                 )
             {
-                $Headers{'Proxy-Authorization'} = 'Basic ' . encode_base64(
-                    $Config->{Proxy}->{ProxyUser} . ':' . $Config->{Proxy}->{ProxyPassword}
+                $Headers{'Proxy-Authorization'} = $Self->_BasicAuthorizationHeader(
+                    User     => $Config->{Proxy}->{ProxyUser},
+                    Password => $Config->{Proxy}->{ProxyPassword},
                 );
             }
         }
@@ -696,8 +697,9 @@ sub RequesterPerformRequest {
             && IsStringWithData( $Config->{Authentication}->{BasicAuthPassword} )
             )
         {
-            $Headers{Authorization} = 'Basic ' . encode_base64(
-                $Config->{Authentication}->{BasicAuthUser} . ':' . $Config->{Authentication}->{BasicAuthPassword}
+            $Headers{Authorization} = $Self->_BasicAuthorizationHeader(
+                User     => $Config->{Authentication}->{BasicAuthUser},
+                Password => $Config->{Authentication}->{BasicAuthPassword},
             );
         }
 
@@ -1334,6 +1336,12 @@ sub _Error {
         Success      => 0,
         ErrorMessage => $Param{Summary},
     };
+}
+
+sub _BasicAuthorizationHeader {
+    my ( $Self, %Param ) = @_;
+
+    return 'Basic ' . encode_base64( "$Param{User}:$Param{Password}", '' );
 }
 
 # introduced for OTOBOTicketInvoker

--- a/scripts/test/GenericInterface/Transport/HTTP/REST/BasicAuthorizationHeader.t
+++ b/scripts/test/GenericInterface/Transport/HTTP/REST/BasicAuthorizationHeader.t
@@ -1,0 +1,62 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+use v5.24;
+use strict;
+use warnings;
+use utf8;
+
+# core modules
+use MIME::Base64 qw(encode_base64);
+
+# CPAN modules
+use Test2::V0;
+
+# OTOBO modules
+use Kernel::GenericInterface::Transport::HTTP::REST;
+
+my $TransportObject = Kernel::GenericInterface::Transport::HTTP::REST->new(
+    DebuggerObject  => {},
+    TransportConfig => {},
+);
+
+for my $Test (
+    {
+        Name     => 'short credentials',
+        User     => 'user',
+        Password => 'password',
+    },
+    {
+        Name     => 'credentials exceeding the MIME line length',
+        User     => 'long-user',
+        Password => 'p' x 100,
+    },
+    )
+{
+    my $Header = $TransportObject->_BasicAuthorizationHeader(
+        User     => $Test->{User},
+        Password => $Test->{Password},
+    );
+
+    is(
+        $Header,
+        'Basic ' . encode_base64( "$Test->{User}:$Test->{Password}", '' ),
+        "$Test->{Name} are encoded without MIME line endings",
+    );
+    unlike( $Header, qr{[\r\n]}, "$Test->{Name} contain no line breaks" );
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Fix Basic authentication header formatting in the REST transport,
addressing an authentication failure encountered with Elasticsearch.

## How to reproduce

1. Configure a REST requester for Elasticsearch with Basic authentication.
2. Trigger an outgoing request.
3. Inspect the generated Authorization header value for line endings.

## Current behavior

The REST transport calls encode_base64 with its default MIME formatting.
This adds a trailing newline, even for short credentials, and additional
line breaks for longer credentials.

The resulting header formatting caused authentication failures in our
Elasticsearch integration. Proxy authentication uses the same encoding.

## Expected behavior

Authorization and Proxy-Authorization header values contain `Basic `
followed by the Base64-encoded credentials without any line endings.

## Changes

- Add a shared helper for server and proxy Basic authentication headers.
- Pass an empty line-ending argument to encode_base64 to disable wrapping
  and trailing newlines.
- Add regression tests covering short and long credentials.

## Testing

Reported passing in the fork PR:

- `prove -q scripts/test/GenericInterface/Transport/HTTP/REST/BasicAuthorizationHeader.t`
  — 4 tests, PASS.
- `git diff --check`