### PR TITLE
Batch Redis cache cleanup scans

### DIFF
--- a/Kernel/System/Cache/Redis.pm
+++ b/Kernel/System/Cache/Redis.pm
@@ -212,7 +212,7 @@ sub CleanUp {
         for my $Type (@ToBeDeletedTypes) {
             my ( $Cursor, $KeysRef ) = ( 0, [] );
             do {
-                ( $Cursor, $KeysRef ) = $Self->{Redis}->scan( $Cursor, MATCH => "$Type:*" );
+                ( $Cursor, $KeysRef ) = $Self->{Redis}->scan( $Cursor, MATCH => "$Type:*", COUNT => 1000 );
                 $Self->{Redis}->del( @{$KeysRef} ) if @{$KeysRef};
             } while ($Cursor);
         }

--- a/scripts/test/Cache/RedisCleanup.t
+++ b/scripts/test/Cache/RedisCleanup.t
@@ -1,0 +1,139 @@
+# --
+# OTOBO is a web-based ticketing system for service organisations.
+# --
+# Copyright (C) 2019-2026 Rother OSS GmbH, https://otobo.io/
+# --
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# --
+
+use v5.24;
+use strict;
+use warnings;
+use utf8;
+
+# CPAN modules
+use Test2::V0;
+
+# OTOBO modules
+use Kernel::System::Cache::Redis;
+
+{
+    package Local::Redis;
+
+    sub new {
+        return bless {
+            Deleted => [],
+            Scans   => [],
+        }, shift;
+    }
+
+    sub scan {
+        my ( $Self, $Cursor, %Param ) = @_;
+
+        push @{ $Self->{Scans} }, [ $Cursor, \%Param ];
+        die "simulated Redis failure\n" if $Self->{Fail};
+
+        my $Type = $Param{MATCH};
+        $Type =~ s{:\*$}{};
+
+        return ( 42, ["$Type:a"] )             if $Cursor == 0;
+        return ( 99, [] )                       if $Cursor == 42;
+        return ( 0,  [ "$Type:a", "$Type:b" ] );
+    }
+
+    sub del {
+        my $Self = shift;
+
+        push @{ $Self->{Deleted} }, [@_];
+
+        return scalar @_;
+    }
+
+    sub flushdb {
+        $_[0]->{Flushed}++;
+
+        return 1;
+    }
+
+    sub smembers {
+        return qw(Target Retained);
+    }
+}
+
+{
+    package Local::Log;
+
+    sub Log {
+        $_[0]->{Errors}++;
+
+        return;
+    }
+}
+
+{
+    package Local::ObjectManager;
+
+    sub Get {
+        return $_[0]->{LogObject};
+    }
+}
+
+$Kernel::OM = bless {
+    LogObject => bless( {}, 'Local::Log' ),
+}, 'Local::ObjectManager';
+
+sub CacheBackendCreate {
+    my $RedisObject = Local::Redis->new();
+
+    return (
+        bless( { Redis => $RedisObject }, 'Kernel::System::Cache::Redis' ),
+        $RedisObject,
+    );
+}
+
+my ( $CacheObject, $RedisObject ) = CacheBackendCreate();
+ok( $CacheObject->CleanUp( Type => 'Target' ), 'target cleanup succeeds' );
+is(
+    $RedisObject->{Scans},
+    [
+        [ 0,  { MATCH => 'Target:*', COUNT => 1000 } ],
+        [ 42, { MATCH => 'Target:*', COUNT => 1000 } ],
+        [ 99, { MATCH => 'Target:*', COUNT => 1000 } ],
+    ],
+    'all SCAN calls use the batch hint and continue through an empty page',
+);
+is(
+    $RedisObject->{Deleted},
+    [ ['Target:a'], [ 'Target:a', 'Target:b' ] ],
+    'all returned keys are deleted and an empty page does not issue DEL',
+);
+is( $RedisObject->{Flushed} || 0, 0, 'target cleanup does not flush the database' );
+
+( $CacheObject, $RedisObject ) = CacheBackendCreate();
+ok( $CacheObject->CleanUp( KeepTypes => ['Retained'] ), 'KeepTypes cleanup succeeds' );
+is(
+    [ map { $_->[1]->{MATCH} } @{ $RedisObject->{Scans} } ],
+    [ ('Target:*') x 3 ],
+    'the retained namespace is not scanned',
+);
+
+( $CacheObject, $RedisObject ) = CacheBackendCreate();
+ok( $CacheObject->CleanUp( Expired => 1 ), 'expiry cleanup is a no-op' );
+is( $RedisObject->{Scans}, [], 'expiry cleanup does not scan' );
+ok( $CacheObject->CleanUp(), 'full cleanup succeeds' );
+is( $RedisObject->{Flushed}, 1, 'full cleanup retains FLUSHDB behavior' );
+
+( $CacheObject, $RedisObject ) = CacheBackendCreate();
+$RedisObject->{Fail} = 1;
+ok( !$CacheObject->CleanUp( Type => 'Target' ), 'Redis errors fail cleanup' );
+is( $Kernel::OM->{LogObject}->{Errors}, 1, 'Redis errors are logged' );
+is( $RedisObject->{Deleted}, [], 'keys are not deleted after a failed SCAN' );
+
+done_testing();


### PR DESCRIPTION
## Summary

Reduce Redis round trips during selective cache cleanup by requesting
larger SCAN batches.

## How to reproduce

1. Configure OTOBO to use the Redis cache backend.
2. Populate the cache with a large number of keys across multiple cache types.
3. Run `Maint::Cache::Delete --type <type>` for a populated cache type.
4. Inspect the Redis commands issued during cleanup.

The existing implementation sends SCAN commands with MATCH but without
an explicit COUNT hint. The same scan loop is used when cleaning up
while retaining selected cache types.

## Current behavior

Selective cleanup iterates through the Redis keyspace separately for
each cache type being removed. Each SCAN uses Redis's default count,
and each non-empty result is followed by a DEL command.

Small scan batches increase the number of round trips needed to
complete cleanup, particularly with a large keyspace.

## Expected behavior

Request larger scan batches while preserving the existing selection,
cursor iteration, and deletion behavior.

COUNT is a work hint rather than a fixed number of returned keys.
Cleanup must therefore continue until the cursor returns to zero,
including when an intermediate scan returns no matching keys.

## Changes

- Add `COUNT => 1000` to selective Redis cleanup scans.
- Preserve namespace matching and cursor-based iteration.
- Add a standalone test using a fake Redis client to cover scan
  arguments, continuation through empty batches, deletion of returned
  keys, repeated keys, retained cache types, expiry-only cleanup,
  full database cleanup, and scan-error handling.

## Testing

Reported passing on the fork PR:
- `prove -q scripts/test/Cache/RedisCleanup.t` — 13 assertions.
- `git diff --check`.